### PR TITLE
Fixed the issue when loading enter feature after heading would break overriding the enter in heading behaviour.

### DIFF
--- a/src/headingengine.js
+++ b/src/headingengine.js
@@ -65,6 +65,9 @@ export default class HeadingEngine extends Plugin {
 		editor.commands.set( 'heading', command );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	afterInit() {
 		// If the enter command is added to the editor, alter its behavior.
 		// Enter at the end of a heading element should create a paragraph.

--- a/src/headingengine.js
+++ b/src/headingengine.js
@@ -63,9 +63,14 @@ export default class HeadingEngine extends Plugin {
 		// Register the heading command.
 		const command = new HeadingCommand( editor, formats );
 		editor.commands.set( 'heading', command );
+	}
 
+	afterInit() {
 		// If the enter command is added to the editor, alter its behavior.
 		// Enter at the end of a heading element should create a paragraph.
+
+		const editor = this.editor;
+		const command = editor.commands.get( 'heading' );
 		const enterCommand = editor.commands.get( 'enter' );
 
 		if ( enterCommand ) {

--- a/tests/tickets/40.js
+++ b/tests/tickets/40.js
@@ -1,0 +1,47 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import HeadingEngine from 'ckeditor5/heading/headingengine.js';
+import VirtualTestEditor from 'tests/core/_utils/virtualtesteditor.js';
+import Enter from 'ckeditor5/enter/enter.js';
+import { getData, setData } from 'ckeditor5/engine/dev-utils/model.js';
+
+describe( 'Bug ckeditor5-heading#40', () => {
+	let editor;
+
+	afterEach( () => {
+		return editor.destroy();
+	} );
+
+	it( 'enter at the end of a heading creates a paragraph, when heading was loaded before enter', () => {
+		return VirtualTestEditor.create( {
+			plugins: [ HeadingEngine, Enter ]
+		} )
+		.then( newEditor => {
+			editor = newEditor;
+
+			setData( editor.document, '<heading1>foo[]</heading1>' );
+
+			editor.execute( 'enter' );
+
+			expect( getData( editor.document ) ).to.equal( '<heading1>foo</heading1><paragraph>[]</paragraph>' );
+		} );
+	} );
+
+	it( 'enter at the end of a heading creates a paragraph, when enter was loaded before heading', () => {
+		return VirtualTestEditor.create( {
+			plugins: [ Enter, HeadingEngine ]
+		} )
+		.then( newEditor => {
+			editor = newEditor;
+
+			setData( editor.document, '<heading1>foo[]</heading1>' );
+
+			editor.execute( 'enter' );
+
+			expect( getData( editor.document ) ).to.equal( '<heading1>foo</heading1><paragraph>[]</paragraph>' );
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes #40.

No ticket manual test, because it's too simple and because we're not performing test phases now (so it would be a waste).