### PR TITLE
t/63: Introduced consistent height and spacing among headings dropdo…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "@ckeditor/ckeditor5-ui": "^0.7.1",
     "@ckeditor/ckeditor5-utils": "^0.8.0",
     "@ckeditor/ckeditor5-engine": "^0.8.0",
-    "@ckeditor/ckeditor5-paragraph": "^0.6.1"
+    "@ckeditor/ckeditor5-paragraph": "^0.6.1",
+    "@ckeditor/ckeditor5-theme-lark": "^0.6.1"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-lint": "^2.0.2",

--- a/theme/theme.scss
+++ b/theme/theme.scss
@@ -1,6 +1,9 @@
 // Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
 // For licensing, see LICENSE.md or http://ckeditor.com/license
 
+@import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_spacing';
+@import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_fonts';
+
 .ck-heading_heading {
 	&1 {
 		font-size: 1.5em;
@@ -13,6 +16,14 @@
 	&3 {
 		font-size: 1.1em;
 	}
+}
+
+// Using absolute units to make sure each element has the same height and padding.
+// https://github.com/ckeditor/ckeditor5-heading/issues/63
+[class*="ck-heading_"] {
+	line-height: 1.8 * $ck-font-size-base;
+	// Strip the units from $ck-def-spacing here.
+	padding: $ck-def-spacing / ( $ck-def-spacing * 0 + 1 ) * $ck-font-size-base;
 }
 
 [class*="ck-heading_heading"] {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Introduced consistent height and spacing among headings dropdown items. Closes #63.

---

### Additional information

Best with https://github.com/ckeditor/ckeditor5-theme-lark/pull/83.

![image](https://cloud.githubusercontent.com/assets/1099479/23947344/ae2bcd2e-097e-11e7-84c9-b9c993f27296.png)
