### PR TITLE
Removed unnecessary HeadingCommand properties

### DIFF
--- a/src/heading.js
+++ b/src/heading.js
@@ -116,14 +116,14 @@ export default class Heading extends Plugin {
 
 	/**
 	 * Returns heading options as defined in `config.heading.options` but processed to consider
-	 * editor localization, i.e. to display {@link module:heading/headingcommand~HeadingOption}
+	 * editor localization, i.e. to display {@link module:heading/heading~HeadingOption}
 	 * in the correct language.
 	 *
 	 * Note: The reason behind this method is that there's no way to use {@link module:utils/locale~Locale#t}
 	 * when the user config is defined because the editor does not exist yet.
 	 *
 	 * @private
-	 * @returns {Array.<module:heading/headingcommand~HeadingOption>}.
+	 * @returns {Array.<module:heading/heading~HeadingOption>}.
 	 */
 	_getLocalizedOptions() {
 		const editor = this.editor;
@@ -159,3 +159,12 @@ export default class Heading extends Plugin {
 function getCommandsBindingTargets( commands, attribute ) {
 	return Array.prototype.concat( ...commands.map( c => [ c, attribute ] ) );
 }
+
+/**
+ * Heading option descriptor.
+ *
+ * @typedef {Object} module:heading/heading~HeadingOption
+ * @property {String} modelElement Element's name in the model.
+ * @property {String} viewElement The name of the view element that will be used to represent the model element in the view.
+ * @property {String} title The user-readable title of the option.
+ */

--- a/src/headingcommand.js
+++ b/src/headingcommand.js
@@ -23,12 +23,19 @@ export default class HeadingCommand extends Command {
 	 * Creates an instance of the command.
 	 *
 	 * @param {module:core/editor/editor~Editor} editor Editor instance.
-	 * @param {module:heading/headingcommand~HeadingOption} option An option to be used by the command instance.
+	 * @param {String} modelElement Name of the element which this command will apply in the model.
 	 */
-	constructor( editor, option ) {
+	constructor( editor, modelElement ) {
 		super( editor );
 
-		Object.assign( this, option );
+		/**
+		 * Unique identifier of the command, also element's name in the model.
+		 * See {@link module:heading/heading~HeadingOption}.
+		 *
+		 * @readonly
+		 * @member {String}
+		 */
+		this.modelElement = modelElement;
 
 		/**
 		 * Value of the command, indicating whether it is applied in the context
@@ -45,30 +52,6 @@ export default class HeadingCommand extends Command {
 			this.refreshValue();
 			this.refreshState();
 		} );
-
-		/**
-		 * Unique identifier of the command, also element's name in the model.
-		 * See {@link module:heading/headingcommand~HeadingOption}.
-		 *
-		 * @readonly
-		 * @member {String} #modelElement
-		 */
-
-		/**
-		 * Element this command creates in the view.
-		 * See {@link module:heading/headingcommand~HeadingOption}.
-		 *
-		 * @readonly
-		 * @member {String} #viewElement
-		 */
-
-		/**
-		 * User-readable title of the command.
-		 * See {@link module:heading/headingcommand~HeadingOption}.
-		 *
-		 * @readonly
-		 * @member {String} #title
-		 */
 	}
 
 	/**
@@ -147,12 +130,3 @@ function checkCanBecomeHeading( block, heading, schema ) {
 		inside: Position.createBefore( block )
 	} );
 }
-
-/**
- * Heading option descriptor.
- *
- * @typedef {Object} module:heading/headingcommand~HeadingOption
- * @property {String} modelElement Element's name in the model.
- * @property {String} viewElement The name of the view element that will be used to represent the model element in the view.
- * @property {String} title The user-readable title of the option.
- */

--- a/src/headingengine.js
+++ b/src/headingengine.js
@@ -74,7 +74,7 @@ export default class HeadingEngine extends Plugin {
 					.toElement( option.modelElement );
 
 				// Register the heading command for this option.
-				editor.commands.set( option.modelElement, new HeadingCommand( editor, option ) );
+				editor.commands.set( option.modelElement, new HeadingCommand( editor, option.modelElement ) );
 			}
 		}
 	}

--- a/tests/headingcommand.js
+++ b/tests/headingcommand.js
@@ -29,7 +29,7 @@ describe( 'HeadingCommand', () => {
 			schema.registerItem( 'paragraph', '$block' );
 
 			for ( const option of options ) {
-				commands[ option.modelElement ] = new HeadingCommand( editor, option );
+				commands[ option.modelElement ] = new HeadingCommand( editor, option.modelElement );
 				schema.registerItem( option.modelElement, '$block' );
 			}
 
@@ -47,18 +47,10 @@ describe( 'HeadingCommand', () => {
 		}
 	} );
 
-	describe( 'basic properties', () => {
-		for ( const option of options ) {
-			test( option );
-		}
-
-		function test( { modelElement, viewElement, title } ) {
-			it( `are set for option.modelElement = ${ modelElement }`, () => {
-				expect( commands[ modelElement ].modelElement ).to.equal( modelElement );
-				expect( commands[ modelElement ].viewElement ).to.equal( viewElement );
-				expect( commands[ modelElement ].title ).to.equal( title );
-			} );
-		}
+	describe( 'modelElement', () => {
+		it( 'is set', () => {
+			expect( commands.heading1.modelElement ).to.equal( 'heading1' );
+		} );
 	} );
 
 	describe( 'value', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Removed `HeadingCommand`'s properties which were exposed unnecessarily. Closes #78.

BREAKING CHANGE: The `HeadingCommand` constructor's second parameter was changed from the options object to the `modelElement` alone.

NOTE: The `HeadingOption` interface was moved to the `heading/heading` module.
