### PR TITLE
Align code to changed config.lang to config.languages

### DIFF
--- a/tests/heading.js
+++ b/tests/heading.js
@@ -226,7 +226,7 @@ describe( 'Heading', () => {
 					.create( editorElement, {
 						plugins: [ Heading ],
 						toolbar: [ 'heading' ],
-						lang: 'pl',
+						language: 'pl',
 						heading: {
 							options
 						}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Aligned code to changes (`config.lang` to `config.languages`). Part of the Translation Service v2 (ckeditor/ckeditor5#624).