### PR TITLE
T/ckeditor5 engine/1198: Update `HeadingOption` to be compatible with `ConverterDefinition`.

### DIFF
--- a/docs/_snippets/features/custom-heading-elements.html
+++ b/docs/_snippets/features/custom-heading-elements.html
@@ -1,0 +1,12 @@
+<style>
+	.fancy {
+		color: #ff0050;
+	}
+</style>
+
+<div id="snippet-custom-heading-levels">
+	<h1>Heading 1</h1>
+	<h2>Heading 2</h2>
+	<h2 class="fancy">Fancy Heading 2</h2>
+	<p>This is <a href="https://ckeditor5.github.io">CKEditor 5</a>.</p>
+</div>

--- a/docs/_snippets/features/custom-heading-elements.html
+++ b/docs/_snippets/features/custom-heading-elements.html
@@ -4,7 +4,7 @@
 	}
 </style>
 
-<div id="snippet-custom-heading-levels">
+<div id="snippet-custom-heading-elements">
 	<h1>Heading 1</h1>
 	<h2>Heading 2</h2>
 	<h2 class="fancy">Fancy Heading 2</h2>

--- a/docs/_snippets/features/custom-heading-elements.html
+++ b/docs/_snippets/features/custom-heading-elements.html
@@ -1,6 +1,7 @@
 <style>
-	.fancy {
+	h2.fancy, .ck-heading_heading2_fancy {
 		color: #ff0050;
+		font-size: 1.3em;
 	}
 </style>
 

--- a/docs/_snippets/features/custom-heading-elements.js
+++ b/docs/_snippets/features/custom-heading-elements.js
@@ -11,7 +11,16 @@ ClassicEditor
 			options: [
 				{ model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
 				{ model: 'heading1', view: 'h1', title: 'Heading 1', class: 'ck-heading_heading1' },
-				{ model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' }
+				{ model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' },
+				{
+					model: 'heading2fancy',
+					view: {
+						name: 'h2',
+						class: 'fancy',
+						priority: 'high'
+					},
+					title: 'Heading 2 (fancy)', class: 'ck-heading_heading2 fancy'
+				}
 			]
 		},
 		toolbar: {

--- a/docs/_snippets/features/custom-heading-elements.js
+++ b/docs/_snippets/features/custom-heading-elements.js
@@ -6,7 +6,7 @@
 /* globals ClassicEditor, console, window, document */
 
 ClassicEditor
-	.create( document.querySelector( '#snippet-custom-heading-levels' ), {
+	.create( document.querySelector( '#snippet-custom-heading-elements' ), {
 		heading: {
 			options: [
 				{ model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },

--- a/docs/_snippets/features/custom-heading-elements.js
+++ b/docs/_snippets/features/custom-heading-elements.js
@@ -13,13 +13,13 @@ ClassicEditor
 				{ model: 'heading1', view: 'h1', title: 'Heading 1', class: 'ck-heading_heading1' },
 				{ model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' },
 				{
-					model: 'heading2fancy',
+					model: 'headingFancy',
 					view: {
 						name: 'h2',
 						class: 'fancy',
 						priority: 'high'
 					},
-					title: 'Heading 2 (fancy)', class: 'ck-heading_heading2 fancy'
+					title: 'Heading 2 (fancy)', class: 'ck-heading_heading2_fancy'
 				}
 			]
 		},

--- a/docs/_snippets/features/custom-heading-levels.js
+++ b/docs/_snippets/features/custom-heading-levels.js
@@ -11,7 +11,17 @@ ClassicEditor
 			options: [
 				{ model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
 				{ model: 'heading1', view: 'h1', title: 'Heading 1', class: 'ck-heading_heading1' },
-				{ model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' }
+				{ model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' },
+				{
+					model: 'heading2fancy',
+					view: {
+						name: 'h2',
+						class: 'fancy',
+						priority: 'high'
+					},
+					title: 'Heading 2 (fancy)',
+					class: 'ck-heading_heading2 fancy'
+				}
 			]
 		},
 		toolbar: {

--- a/docs/_snippets/features/custom-heading-levels.js
+++ b/docs/_snippets/features/custom-heading-levels.js
@@ -11,17 +11,7 @@ ClassicEditor
 			options: [
 				{ model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
 				{ model: 'heading1', view: 'h1', title: 'Heading 1', class: 'ck-heading_heading1' },
-				{ model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' },
-				{
-					model: 'heading2fancy',
-					view: {
-						name: 'h2',
-						class: 'fancy',
-						priority: 'high'
-					},
-					title: 'Heading 2 (fancy)',
-					class: 'ck-heading_heading2 fancy'
-				}
+				{ model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' }
 			]
 		},
 		toolbar: {

--- a/docs/features/headings.md
+++ b/docs/features/headings.md
@@ -53,14 +53,16 @@ ClassicEditor
 
 ### Configuring custom heading elements
 
-It is also possible to define custom elements for headings using {@link module:engine/view/viewelementdefinition~ViewElementDefinition}.
+It is also possible to define fully custom elements for headings by using the {@link module:engine/view/viewelementdefinition~ViewElementDefinition advanced format} of the {@link module:heading/heading~HeadingConfig#options `heading.options`} configuration option.
 
-For example, the following editor will support `heading2fancy` that differs from `heading2` in view by extra `class` property: 
+For example, the following editor will support the following two heading options at the same time: `<h2 class="fancy">` and `<h2>`:
 
 ```html
 <style>
-	.fancy {
+	// Style for the heading in the content and for the dropdown item.
+	h2.fancy, .ck-heading_heading2_fancy {
 		color: #ff0050;
+		font-size: 1.3em;
 	}
 </style>
 
@@ -70,7 +72,6 @@ For example, the following editor will support `heading2fancy` that differs from
 	<h2 class="fancy">Fancy Heading 2</h2>
 	<p>This is <a href="https://ckeditor5.github.io">CKEditor 5</a>.</p>
 </div>
-
 ```
 
 ```js
@@ -82,14 +83,16 @@ ClassicEditor
 				{ model: 'heading1', view: 'h1', title: 'Heading 1', class: 'ck-heading_heading1' },
 				{ model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' },
 				{
-					model: 'heading2fancy',
+					model: 'headingFancy',
 					view: {
 						name: 'h2',
 						class: 'fancy',
+
+						// It needs to be converted before the standard 'heading2'.
 						priority: 'high'
 					},
 					title: 'Heading 2 (fancy)',
-					class: 'ck-heading_heading2 fancy'
+					class: 'ck-heading_heading2_fancy'
 				}
 			]
 		}

--- a/docs/features/headings.md
+++ b/docs/features/headings.md
@@ -59,7 +59,7 @@ For example, the following editor will support the following two heading options
 
 ```html
 <style>
-	// Style for the heading in the content and for the dropdown item.
+	// Styles for the heading in the content and for the dropdown item.
 	h2.fancy, .ck-heading_heading2_fancy {
 		color: #ff0050;
 		font-size: 1.3em;

--- a/docs/features/headings.md
+++ b/docs/features/headings.md
@@ -39,9 +39,9 @@ ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		heading: {
 			options: [
-				{ modelElement: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
-				{ modelElement: 'heading1', viewElement: 'h1', title: 'Heading 1', class: 'ck-heading_heading1' },
-				{ modelElement: 'heading2', viewElement: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' }
+				{ model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
+				{ model: 'heading1', view: 'h1', title: 'Heading 1', class: 'ck-heading_heading1' },
+				{ model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' }
 			]
 		}
 	} )
@@ -50,6 +50,55 @@ ClassicEditor
 ```
 
 {@snippet features/custom-heading-levels}
+
+### Configuring custom heading elements
+
+It is also possible to define custom elements for headings using {@link module:engine/view/viewelementdefinition~ViewElementDefinition}.
+
+For example, the following editor will support `heading2fancy` that differs from `heading2` in view by extra `class` property: 
+
+```html
+<style>
+	.fancy {
+		color: #ff0050;
+	}
+</style>
+
+<div id="snippet-custom-heading-levels">
+	<h1>Heading 1</h1>
+	<h2>Heading 2</h2>
+	<h2 class="fancy">Fancy Heading 2</h2>
+	<p>This is <a href="https://ckeditor5.github.io">CKEditor 5</a>.</p>
+</div>
+
+```
+
+```js
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		heading: {
+			options: [
+				{ model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
+				{ model: 'heading1', view: 'h1', title: 'Heading 1', class: 'ck-heading_heading1' },
+				{ model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' },
+				{
+					model: 'heading2fancy',
+					view: {
+						name: 'h2',
+						class: 'fancy',
+						priority: 'high'
+					},
+					title: 'Heading 2 (fancy)',
+					class: 'ck-heading_heading2 fancy'
+				}
+			]
+		}
+	} )
+	.then( ... )
+	.catch( ... );
+```
+
+{@snippet features/custom-heading-elements}
 
 ## Installation
 

--- a/src/heading.js
+++ b/src/heading.js
@@ -162,13 +162,16 @@ function getCommandsBindingTargets( commands, attribute ) {
 }
 
 /**
- * Heading option descriptor.
+ * Heading option descriptor. Compatible with {@link module:engine/conversion/definition-based-converters~ConverterDefinition}.
  *
  * @typedef {Object} module:heading/heading~HeadingOption
  * @property {String} model Element's name in the model.
- * @property {String} view The name of the view element that will be used to represent the model element in the view.
+ * @property {module:engine/view/viewelementdefinition~ViewElementDefinition} view The name of the view element
+ * or {@link module:engine/view/viewelementdefinition~ViewElementDefinition} that will be used to represent the model element in the view.
  * @property {String} title The user-readable title of the option.
  * @property {String} class The class which will be added to the dropdown item representing this option.
+ * @property {Array.<module:engine/view/viewelementdefinition~ViewElementDefinition>} acceptAlso An array with all matched elements that
+ * view to model conversion should also accept.
  */
 
 /**

--- a/src/heading.js
+++ b/src/heading.js
@@ -162,19 +162,6 @@ function getCommandsBindingTargets( commands, attribute ) {
 }
 
 /**
- * Heading option descriptor. Compatible with {@link module:engine/conversion/definition-based-converters~ConverterDefinition}.
- *
- * @typedef {Object} module:heading/heading~HeadingOption
- * @property {String} model Element's name in the model.
- * @property {module:engine/view/viewelementdefinition~ViewElementDefinition} view The name of the view element
- * or {@link module:engine/view/viewelementdefinition~ViewElementDefinition} that will be used to represent the model element in the view.
- * @property {String} title The user-readable title of the option.
- * @property {String} class The class which will be added to the dropdown item representing this option.
- * @property {Array.<module:engine/view/viewelementdefinition~ViewElementDefinition>} acceptAlso An array with all matched elements that
- * view to model conversion should also accept.
- */
-
-/**
  * The configuration of the heading feature. Introduced by the {@link module:heading/headingengine~HeadingEngine} feature.
  *
  * Read more in {@link module:heading/heading~HeadingConfig}.
@@ -223,6 +210,9 @@ function getCommandsBindingTargets( commands, attribute ) {
  * the {@link module:paragraph/paragraph~Paragraph} feature (which is required by
  * the {@link module:heading/headingengine~HeadingEngine} feature).
  *
+ * You can **read more** about configuring heading levels and **see more examples** in
+ * the {@glink features/headings Headings} guide.
+ *
  * Note: In the model you should always start from `heading1`, regardless of how the headings are represented in the view.
  * That's assumption is used by features like {@link module:autoformat/autoformat~Autoformat} to know which element
  * they should use when applying the first level heading.
@@ -233,4 +223,16 @@ function getCommandsBindingTargets( commands, attribute ) {
  *		editor.execute( 'heading1' );
  *
  * @member {Array.<module:heading/heading~HeadingOption>} module:heading/heading~HeadingConfig#options
+ */
+
+/**
+ * Heading option descriptor.
+ *
+ * This format is compatible with {@link module:engine/conversion/definition-based-converters~ConverterDefinition}
+ * and adds to additional properties: `title` and `class`.
+ *
+ * @typedef {Object} module:heading/heading~HeadingOption
+ * @extends module:engine/conversion/definition-based-converters~ConverterDefinition
+ * @property {String} title The user-readable title of the option.
+ * @property {String} class The class which will be added to the dropdown item representing this option.
  */

--- a/src/heading.js
+++ b/src/heading.js
@@ -52,9 +52,9 @@ export default class Heading extends Plugin {
 		const dropdownTooltip = t( 'Heading' );
 
 		for ( const option of options ) {
-			const command = editor.commands.get( option.modelElement );
+			const command = editor.commands.get( option.model );
 			const itemModel = new Model( {
-				commandName: option.modelElement,
+				commandName: option.model,
 				label: option.title,
 				class: option.class
 			} );
@@ -165,8 +165,8 @@ function getCommandsBindingTargets( commands, attribute ) {
  * Heading option descriptor.
  *
  * @typedef {Object} module:heading/heading~HeadingOption
- * @property {String} modelElement Element's name in the model.
- * @property {String} viewElement The name of the view element that will be used to represent the model element in the view.
+ * @property {String} model Element's name in the model.
+ * @property {String} view The name of the view element that will be used to represent the model element in the view.
  * @property {String} title The user-readable title of the option.
  * @property {String} class The class which will be added to the dropdown item representing this option.
  */
@@ -202,10 +202,10 @@ function getCommandsBindingTargets( commands, attribute ) {
  *
  *		const headingConfig = {
  *			options: [
- *				{ modelElement: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
- *				{ modelElement: 'heading1', viewElement: 'h2', title: 'Heading 1', class: 'ck-heading_heading1' },
- *				{ modelElement: 'heading2', viewElement: 'h3', title: 'Heading 2', class: 'ck-heading_heading2' },
- *				{ modelElement: 'heading3', viewElement: 'h4', title: 'Heading 3', class: 'ck-heading_heading3' }
+ *				{ model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
+ *				{ model: 'heading1', view: 'h2', title: 'Heading 1', class: 'ck-heading_heading1' },
+ *				{ model: 'heading2', view: 'h3', title: 'Heading 2', class: 'ck-heading_heading2' },
+ *				{ model: 'heading3', view: 'h4', title: 'Heading 3', class: 'ck-heading_heading3' }
  *			]
  *		};
  *

--- a/src/headingengine.js
+++ b/src/headingengine.js
@@ -33,35 +33,10 @@ export default class HeadingEngine extends Plugin {
 
 		editor.config.define( 'heading', {
 			options: [
-				{
-					model: 'paragraph',
-					title: 'Paragraph',
-					class: 'ck-heading_paragraph'
-				},
-				{
-					model: 'heading1',
-					title: 'Heading 1',
-					class: 'ck-heading_heading1',
-					view: {
-						name: 'h2'
-					}
-				},
-				{
-					model: 'heading2',
-					title: 'Heading 2',
-					view: {
-						name: 'h3'
-					},
-					class: 'ck-heading_heading2'
-				},
-				{
-					model: 'heading3',
-					title: 'Heading 3',
-					class: 'ck-heading_heading3',
-					view: {
-						name: 'h4'
-					}
-				}
+				{ model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
+				{ model: 'heading1', view: 'h2', title: 'Heading 1', class: 'ck-heading_heading1' },
+				{ model: 'heading2', view: 'h3', title: 'Heading 2', class: 'ck-heading_heading2' },
+				{ model: 'heading3', view: 'h4', title: 'Heading 3', class: 'ck-heading_heading3' }
 			]
 		} );
 	}

--- a/src/headingengine.js
+++ b/src/headingengine.js
@@ -9,7 +9,7 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import { modelElementToView, viewToModelElement } from '@ckeditor/ckeditor5-engine/src/conversion/elementconverters';
+import { containerElementToView, viewToContainerElement } from '@ckeditor/ckeditor5-engine/src/conversion/containerelementconverters.js';
 
 import HeadingCommand from './headingcommand';
 
@@ -86,10 +86,10 @@ export default class HeadingEngine extends Plugin {
 				editor.document.schema.registerItem( option.model, '$block' );
 
 				// Build converter from model to view for data and editing pipelines.
-				modelElementToView( option, [ data.modelToView, editing.modelToView ] );
+				containerElementToView( option, [ data.modelToView, editing.modelToView ] );
 
 				// Build converter from view to model for data pipeline.
-				viewToModelElement( option, [ data.viewToModel ] );
+				viewToContainerElement( option, [ data.viewToModel ] );
 
 				// Register the heading command for this option.
 				editor.commands.add( option.model, new HeadingCommand( editor, option.model ) );

--- a/src/headingengine.js
+++ b/src/headingengine.js
@@ -9,7 +9,10 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import { containerElementToView, viewToContainerElement } from '@ckeditor/ckeditor5-engine/src/conversion/containerelementconverters.js';
+import {
+	containerElementToView,
+	viewToContainerElement
+} from '@ckeditor/ckeditor5-engine/src/conversion/configurationdefinedconverters';
 
 import HeadingCommand from './headingcommand';
 

--- a/src/headingengine.js
+++ b/src/headingengine.js
@@ -10,8 +10,8 @@
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import {
-	containerElementToView,
-	viewToContainerElement
+	modelElementToViewContainerElement,
+	viewToModelElement
 } from '@ckeditor/ckeditor5-engine/src/conversion/configurationdefinedconverters';
 
 import HeadingCommand from './headingcommand';
@@ -89,10 +89,10 @@ export default class HeadingEngine extends Plugin {
 				editor.document.schema.registerItem( option.model, '$block' );
 
 				// Build converter from model to view for data and editing pipelines.
-				containerElementToView( option, [ data.modelToView, editing.modelToView ] );
+				modelElementToViewContainerElement( option, [ data.modelToView, editing.modelToView ] );
 
 				// Build converter from view to model for data pipeline.
-				viewToContainerElement( option, [ data.viewToModel ] );
+				viewToModelElement( option, [ data.viewToModel ] );
 
 				// Register the heading command for this option.
 				editor.commands.add( option.model, new HeadingCommand( editor, option.model ) );

--- a/src/headingengine.js
+++ b/src/headingengine.js
@@ -30,10 +30,35 @@ export default class HeadingEngine extends Plugin {
 
 		editor.config.define( 'heading', {
 			options: [
-				{ modelElement: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
-				{ modelElement: 'heading1', viewElement: 'h2', title: 'Heading 1', class: 'ck-heading_heading1' },
-				{ modelElement: 'heading2', viewElement: 'h3', title: 'Heading 2', class: 'ck-heading_heading2' },
-				{ modelElement: 'heading3', viewElement: 'h4', title: 'Heading 3', class: 'ck-heading_heading3' }
+				{
+					model: 'paragraph',
+					title: 'Paragraph',
+					class: 'ck-heading_paragraph'
+				},
+				{
+					model: 'heading1',
+					title: 'Heading 1',
+					class: 'ck-heading_heading1',
+					view: {
+						name: 'h2'
+					}
+				},
+				{
+					model: 'heading2',
+					title: 'Heading 2',
+					view: {
+						name: 'h3'
+					},
+					class: 'ck-heading_heading2'
+				},
+				{
+					model: 'heading3',
+					title: 'Heading 3',
+					class: 'ck-heading_heading3',
+					view: {
+						name: 'h4'
+					}
+				}
 			]
 		} );
 	}
@@ -56,22 +81,22 @@ export default class HeadingEngine extends Plugin {
 
 		for ( const option of options ) {
 			// Skip paragraph - it is defined in required Paragraph feature.
-			if ( option.modelElement !== defaultModelElement ) {
+			if ( option.model !== defaultModelElement ) {
 				// Schema.
-				editor.document.schema.registerItem( option.modelElement, '$block' );
+				editor.document.schema.registerItem( option.model, '$block' );
 
 				// Build converter from model to view for data and editing pipelines.
 				buildModelConverter().for( data.modelToView, editing.modelToView )
-					.fromElement( option.modelElement )
-					.toElement( option.viewElement );
+					.fromElement( option.model )
+					.toElement( option.view.name );
 
 				// Build converter from view to model for data pipeline.
 				buildViewConverter().for( data.viewToModel )
-					.fromElement( option.viewElement )
-					.toElement( option.modelElement );
+					.from( { name: option.view.name } )
+					.toElement( option.model );
 
 				// Register the heading command for this option.
-				editor.commands.add( option.modelElement, new HeadingCommand( editor, option.modelElement ) );
+				editor.commands.add( option.model, new HeadingCommand( editor, option.model ) );
 			}
 		}
 	}
@@ -90,7 +115,7 @@ export default class HeadingEngine extends Plugin {
 			this.listenTo( enterCommand, 'afterExecute', ( evt, data ) => {
 				const positionParent = editor.document.selection.getFirstPosition().parent;
 				const batch = data.batch;
-				const isHeading = options.some( option => positionParent.is( option.modelElement ) );
+				const isHeading = options.some( option => positionParent.is( option.model ) );
 
 				if ( isHeading && !positionParent.is( defaultModelElement ) && positionParent.childCount === 0 ) {
 					batch.rename( positionParent, defaultModelElement );

--- a/src/headingengine.js
+++ b/src/headingengine.js
@@ -86,10 +86,10 @@ export default class HeadingEngine extends Plugin {
 				editor.document.schema.registerItem( option.model, '$block' );
 
 				// Build converter from model to view for data and editing pipelines.
-				modelElementToView( option.model, option.view, [ data.modelToView, editing.modelToView ] );
+				modelElementToView( option, [ data.modelToView, editing.modelToView ] );
 
 				// Build converter from view to model for data pipeline.
-				viewToModelElement( option.model, option.view, [ data.viewToModel ] );
+				viewToModelElement( option, [ data.viewToModel ] );
 
 				// Register the heading command for this option.
 				editor.commands.add( option.model, new HeadingCommand( editor, option.model ) );

--- a/src/headingengine.js
+++ b/src/headingengine.js
@@ -12,7 +12,7 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import {
 	modelElementToViewContainerElement,
 	viewToModelElement
-} from '@ckeditor/ckeditor5-engine/src/conversion/configurationdefinedconverters';
+} from '@ckeditor/ckeditor5-engine/src/conversion/definition-based-converters';
 
 import HeadingCommand from './headingcommand';
 

--- a/src/headingengine.js
+++ b/src/headingengine.js
@@ -8,9 +8,9 @@
  */
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-import buildModelConverter from '@ckeditor/ckeditor5-engine/src/conversion/buildmodelconverter';
-import buildViewConverter from '@ckeditor/ckeditor5-engine/src/conversion/buildviewconverter';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import { modelElementToView, viewToModelElement } from '@ckeditor/ckeditor5-engine/src/conversion/elementconverters';
+
 import HeadingCommand from './headingcommand';
 
 const defaultModelElement = 'paragraph';
@@ -86,14 +86,10 @@ export default class HeadingEngine extends Plugin {
 				editor.document.schema.registerItem( option.model, '$block' );
 
 				// Build converter from model to view for data and editing pipelines.
-				buildModelConverter().for( data.modelToView, editing.modelToView )
-					.fromElement( option.model )
-					.toElement( option.view.name );
+				modelElementToView( option.model, option.view, [ data.modelToView, editing.modelToView ] );
 
 				// Build converter from view to model for data pipeline.
-				buildViewConverter().for( data.viewToModel )
-					.from( { name: option.view.name } )
-					.toElement( option.model );
+				viewToModelElement( option.model, option.view, [ data.viewToModel ] );
 
 				// Register the heading command for this option.
 				editor.commands.add( option.model, new HeadingCommand( editor, option.model ) );

--- a/tests/heading.js
+++ b/tests/heading.js
@@ -118,8 +118,8 @@ describe( 'Heading', () => {
 			beforeEach( () => {
 				commands = {};
 
-				editor.config.get( 'heading.options' ).forEach( ( { modelElement } ) => {
-					commands[ modelElement ] = editor.commands.get( modelElement );
+				editor.config.get( 'heading.options' ).forEach( ( { model } ) => {
+					commands[ model ] = editor.commands.get( model );
 				} );
 			} );
 
@@ -151,17 +151,17 @@ describe( 'Heading', () => {
 
 			beforeEach( () => {
 				return localizedEditor( [
-					{ modelElement: 'paragraph', title: 'Paragraph' },
-					{ modelElement: 'heading1', viewElement: 'h2', title: 'Heading 1' },
-					{ modelElement: 'heading2', viewElement: 'h3', title: 'Heading 2' }
+					{ model: 'paragraph', title: 'Paragraph' },
+					{ model: 'heading1', view: { name: 'h2' }, title: 'Heading 1' },
+					{ model: 'heading2', view: { name: 'h3' }, title: 'Heading 2' }
 				] );
 			} );
 
 			it( 'does not alter the original config', () => {
 				expect( editor.config.get( 'heading.options' ) ).to.deep.equal( [
-					{ modelElement: 'paragraph', title: 'Paragraph' },
-					{ modelElement: 'heading1', viewElement: 'h2', title: 'Heading 1' },
-					{ modelElement: 'heading2', viewElement: 'h3', title: 'Heading 2' }
+					{ model: 'paragraph', title: 'Paragraph' },
+					{ model: 'heading1', view: { name: 'h2' }, title: 'Heading 1' },
+					{ model: 'heading2', view: { name: 'h3' }, title: 'Heading 2' }
 				] );
 			} );
 
@@ -194,8 +194,8 @@ describe( 'Heading', () => {
 
 			it( 'allows custom titles', () => {
 				return localizedEditor( [
-					{ modelElement: 'paragraph', title: 'Custom paragraph title' },
-					{ modelElement: 'heading1', title: 'Custom heading1 title' }
+					{ model: 'paragraph', title: 'Custom paragraph title' },
+					{ model: 'heading1', view: { name: 'h1' }, title: 'Custom heading1 title' }
 				] ).then( () => {
 					const listView = dropdown.listView;
 
@@ -208,7 +208,7 @@ describe( 'Heading', () => {
 
 			it( 'translates default using the the locale', () => {
 				return localizedEditor( [
-					{ modelElement: 'paragraph', title: 'Paragraph' }
+					{ model: 'paragraph', title: 'Paragraph' }
 				] ).then( () => {
 					const listView = dropdown.listView;
 
@@ -236,8 +236,8 @@ describe( 'Heading', () => {
 						dropdown = editor.ui.componentFactory.create( 'headings' );
 						commands = {};
 
-						editor.config.get( 'heading.options' ).forEach( ( { modelElement } ) => {
-							commands[ modelElement ] = editor.commands.get( modelElement );
+						editor.config.get( 'heading.options' ).forEach( ( { model } ) => {
+							commands[ model ] = editor.commands.get( model );
 						} );
 
 						editorElement.remove();

--- a/tests/headingcommand.js
+++ b/tests/headingcommand.js
@@ -10,9 +10,9 @@ import Range from '@ckeditor/ckeditor5-engine/src/model/range';
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 const options = [
-	{ modelElement: 'heading1', viewElement: 'h2', title: 'H2' },
-	{ modelElement: 'heading2', viewElement: 'h3', title: 'H3' },
-	{ modelElement: 'heading3', viewElement: 'h4', title: 'H4' }
+	{ model: 'heading1', view: { name: 'h2' }, title: 'H2' },
+	{ model: 'heading2', view: { name: 'h3' }, title: 'H3' },
+	{ model: 'heading3', view: { name: 'h4' }, title: 'H4' }
 ];
 
 describe( 'HeadingCommand', () => {
@@ -29,8 +29,8 @@ describe( 'HeadingCommand', () => {
 			schema.registerItem( 'paragraph', '$block' );
 
 			for ( const option of options ) {
-				commands[ option.modelElement ] = new HeadingCommand( editor, option.modelElement );
-				schema.registerItem( option.modelElement, '$block' );
+				commands[ option.model ] = new HeadingCommand( editor, option.model );
+				schema.registerItem( option.model, '$block' );
 			}
 
 			schema.registerItem( 'notBlock' );
@@ -58,7 +58,7 @@ describe( 'HeadingCommand', () => {
 			test( option );
 		}
 
-		function test( { modelElement } ) {
+		function test( { model: modelElement } ) {
 			it( `equals ${ modelElement } when collapsed selection is placed inside ${ modelElement } element`, () => {
 				setData( document, `<${ modelElement }>foobar</${ modelElement }>` );
 				const element = root.getChild( 0 );
@@ -176,11 +176,11 @@ describe( 'HeadingCommand', () => {
 			} );
 
 			function test( from, to ) {
-				it( `converts ${ from.modelElement } to ${ to.modelElement } on collapsed selection`, () => {
-					setData( document, `<${ from.modelElement }>foo[]bar</${ from.modelElement }>` );
-					commands[ to.modelElement ].execute();
+				it( `converts ${ from.model } to ${ to.model } on collapsed selection`, () => {
+					setData( document, `<${ from.model }>foo[]bar</${ from.model }>` );
+					commands[ to.model ].execute();
 
-					expect( getData( document ) ).to.equal( `<${ to.modelElement }>foo[]bar</${ to.modelElement }>` );
+					expect( getData( document ) ).to.equal( `<${ to.model }>foo[]bar</${ to.model }>` );
 				} );
 			}
 		} );
@@ -221,7 +221,7 @@ describe( 'HeadingCommand', () => {
 				);
 			} );
 
-			function test( { modelElement: fromElement }, { modelElement: toElement } ) {
+			function test( { model: fromElement }, { model: toElement } ) {
 				it( `converts ${ fromElement } to ${ toElement } on non-collapsed selection`, () => {
 					setData(
 						document,
@@ -240,7 +240,7 @@ describe( 'HeadingCommand', () => {
 
 	describe( 'isEnabled', () => {
 		for ( const option of options ) {
-			test( option.modelElement );
+			test( option.model );
 		}
 
 		function test( modelElement ) {

--- a/tests/headingengine.js
+++ b/tests/headingengine.js
@@ -85,15 +85,10 @@ describe( 'HeadingEngine', () => {
 							{ model: 'paragraph', title: 'paragraph' },
 							{
 								model: 'heading1',
-								view: {
-									from: [
-										{ name: 'h1' },
-										{ name: 'p', attribute: { 'data-heading': 'h1' }, priority: 'high' }
-									],
-									to: {
-										name: 'h1'
-									}
-								},
+								view: 'h1',
+								acceptsAlso: [
+									{ name: 'p', attribute: { 'data-heading': 'h1' }, priority: 'high' }
+								],
 								title: 'User H1'
 							}
 						]
@@ -172,3 +167,4 @@ describe( 'HeadingEngine', () => {
 		} );
 	} );
 } );
+

--- a/tests/headingengine.js
+++ b/tests/headingengine.js
@@ -87,18 +87,18 @@ describe( 'HeadingEngine', () => {
 			describe( 'default value', () => {
 				it( 'should be set', () => {
 					expect( editor.config.get( 'heading.options' ) ).to.deep.equal( [
-						{ modelElement: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
-						{ modelElement: 'heading1', viewElement: 'h2', title: 'Heading 1', class: 'ck-heading_heading1' },
-						{ modelElement: 'heading2', viewElement: 'h3', title: 'Heading 2', class: 'ck-heading_heading2' },
-						{ modelElement: 'heading3', viewElement: 'h4', title: 'Heading 3', class: 'ck-heading_heading3' }
+						{ model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
+						{ model: 'heading1', view: { name: 'h2' }, title: 'Heading 1', class: 'ck-heading_heading1' },
+						{ model: 'heading2', view: { name: 'h3' }, title: 'Heading 2', class: 'ck-heading_heading2' },
+						{ model: 'heading3', view: { name: 'h4' }, title: 'Heading 3', class: 'ck-heading_heading3' }
 					] );
 				} );
 			} );
 
 			it( 'should customize options', () => {
 				const options = [
-					{ modelElement: 'paragraph', title: 'Paragraph' },
-					{ modelElement: 'h4', viewElement: 'h4', title: 'H4' }
+					{ model: 'paragraph', title: 'Paragraph' },
+					{ model: 'h4', view: { name: 'h4' }, title: 'H4' }
 				];
 
 				return VirtualTestEditor

--- a/tests/headingengine.js
+++ b/tests/headingengine.js
@@ -87,7 +87,7 @@ describe( 'HeadingEngine', () => {
 								model: 'heading1',
 								view: 'h1',
 								acceptsAlso: [
-									{ name: 'p', attribute: { 'data-heading': 'h1' }, priority: 'high' }
+									{ name: 'p', attributes: { 'data-heading': 'h1' }, priority: 'high' }
 								],
 								title: 'User H1'
 							}

--- a/tests/headingengine.js
+++ b/tests/headingengine.js
@@ -87,7 +87,7 @@ describe( 'HeadingEngine', () => {
 								model: 'heading1',
 								view: 'h1',
 								acceptsAlso: [
-									{ name: 'p', attributes: { 'data-heading': 'h1' }, priority: 'high' }
+									{ name: 'p', attribute: { 'data-heading': 'h1' }, priority: 'high' }
 								],
 								title: 'User H1'
 							}

--- a/tests/headingengine.js
+++ b/tests/headingengine.js
@@ -130,9 +130,9 @@ describe( 'HeadingEngine', () => {
 				it( 'should be set', () => {
 					expect( editor.config.get( 'heading.options' ) ).to.deep.equal( [
 						{ model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
-						{ model: 'heading1', view: { name: 'h2' }, title: 'Heading 1', class: 'ck-heading_heading1' },
-						{ model: 'heading2', view: { name: 'h3' }, title: 'Heading 2', class: 'ck-heading_heading2' },
-						{ model: 'heading3', view: { name: 'h4' }, title: 'Heading 3', class: 'ck-heading_heading3' }
+						{ model: 'heading1', view: 'h2', title: 'Heading 1', class: 'ck-heading_heading1' },
+						{ model: 'heading2', view: 'h3', title: 'Heading 2', class: 'ck-heading_heading2' },
+						{ model: 'heading3', view: 'h4', title: 'Heading 3', class: 'ck-heading_heading3' }
 					] );
 				} );
 			} );

--- a/tests/headingengine.js
+++ b/tests/headingengine.js
@@ -75,6 +75,53 @@ describe( 'HeadingEngine', () => {
 		expect( editor.getData() ).to.equal( '<h4>foobar</h4>' );
 	} );
 
+	describe( 'user defined', () => {
+		beforeEach( () => {
+			return VirtualTestEditor
+				.create( {
+					plugins: [ HeadingEngine ],
+					heading: {
+						options: [
+							{ model: 'paragraph', title: 'paragraph' },
+							{
+								model: 'heading1',
+								view: {
+									from: [
+										{ name: 'h1' },
+										{ name: 'p', attribute: { 'data-heading': 'h1' }, priority: 'high' }
+									],
+									to: {
+										name: 'h1'
+									}
+								},
+								title: 'User H1'
+							}
+						]
+					}
+				} )
+				.then( newEditor => {
+					editor = newEditor;
+					document = editor.document;
+				} );
+		} );
+
+		it( 'should convert from defined h element', () => {
+			editor.setData( '<h1>foobar</h1>' );
+
+			expect( getData( document, { withoutSelection: true } ) ).to.equal( '<heading1>foobar</heading1>' );
+			expect( editor.getData() ).to.equal( '<h1>foobar</h1>' );
+		} );
+
+		it( 'should convert from defined paragraph with attributes', () => {
+			editor.setData( '<p data-heading="h1">foobar</p><p>Normal paragraph</p>' );
+
+			expect( getData( document, { withoutSelection: true } ) )
+				.to.equal( '<heading1>foobar</heading1><paragraph>Normal paragraph</paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<h1>foobar</h1><p>Normal paragraph</p>' );
+		} );
+	} );
+
 	it( 'should not blow up if there\'s no enter command in the editor', () => {
 		return VirtualTestEditor
 			.create( {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Enhancement: Add support `ConverterDefinition` in Heading. Closes #72. Closes ckeditor/ckeditor5#651.

BREAKING CHANGE: `config.heading.options` format has changed. The valid `HeadingOption` syntax is now compatible with `ConverterDefinition`: `{ model: 'heading1', view: 'h1', title: 'Heading 1' }`.

---

### Additional information

* Requires ckeditor/ckeditor5-engine#1198 to be closed.
* I had troubles with documenting `HeadingOption` as it "extends" `ConverterDefinition` any insights on this will be helpful.
