### PR TITLE
Moved conversion.two-way-converters to conversion.Conversion

### DIFF
--- a/src/headingengine.js
+++ b/src/headingengine.js
@@ -9,7 +9,6 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import { elementToElement } from '@ckeditor/ckeditor5-engine/src/conversion/two-way-converters';
 
 import HeadingCommand from './headingcommand';
 
@@ -60,7 +59,7 @@ export default class HeadingEngine extends Plugin {
 					inheritAllFrom: '$block'
 				} );
 
-				elementToElement( editor.conversion, {
+				editor.conversion.elementToElement( {
 					model: option.model,
 					view: option.view,
 					upcastAlso: option.upcastAlso


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Moved `conversion.two-way-converters` to `conversion.Conversion`.

---

### Additional information

Required by https://github.com/ckeditor/ckeditor5-engine/pull/1297
