### PR TITLE
Other: Update naming of UI components & commands.

### DIFF
--- a/docs/features/headings.md
+++ b/docs/features/headings.md
@@ -133,12 +133,12 @@ ClassicEditor
 The {@link module:heading/heading~Heading} plugin registers:
 
 * The `'heading'` dropdown.
-* The `'heading1'`, `'heading2'`, ..., `'headingN'` commands based on the {@link module:heading/heading~HeadingConfig#options `heading.options`} configuration option.
+* The `'heading'` command that accepts value based on the {@link module:heading/heading~HeadingConfig#options `heading.options`} configuration option.
 
 	You can turn the currently selected block(s) to headings by executing one of these commands:
 
 	```js
-	editor.execute( 'heading2' );
+	editor.execute( 'heading', { value: 'heading2' } );
 	```
 
 ## Contribute

--- a/docs/features/headings.md
+++ b/docs/features/headings.md
@@ -122,7 +122,7 @@ import Heading from '@ckeditor/ckeditor5-heading/src/heading';
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [ Heading, ... ],
-		toolbar: [ 'headings', ... ]
+		toolbar: [ 'heading', ... ]
 	} )
 	.then( ... )
 	.catch( ... );
@@ -132,7 +132,7 @@ ClassicEditor
 
 The {@link module:heading/heading~Heading} plugin registers:
 
-* The `'headings'` dropdown.
+* The `'heading'` dropdown.
 * The `'heading1'`, `'heading2'`, ..., `'headingN'` commands based on the {@link module:heading/heading~HeadingConfig#options `heading.options`} configuration option.
 
 	You can turn the currently selected block(s) to headings by executing one of these commands:

--- a/src/heading.js
+++ b/src/heading.js
@@ -95,10 +95,10 @@ export default class Heading extends Plugin {
  * That's assumption is used by features like {@link module:autoformat/autoformat~Autoformat} to know which element
  * they should use when applying the first level heading.
  *
- * The defined headings are also available in {@link module:core/commandcollection~CommandCollection} under their model names.
+ * The defined headings are also available as values passed to `heading` command under their model names.
  * For example, the below code will apply `<heading1>` to the current selection:
  *
- *		editor.execute( 'heading1' );
+ *		editor.execute( 'heading', { value: 'heading1' } );
  *
  * @member {Array.<module:heading/heading~HeadingOption>} module:heading/heading~HeadingConfig#options
  */

--- a/src/headingcommand.js
+++ b/src/headingcommand.js
@@ -26,7 +26,7 @@ export default class HeadingCommand extends Command {
 		super( editor );
 
 		/**
-		 * Whether the selection starts in a heading of {@link #modelElement this level}.
+		 * Whether the selection starts in a heading of {@link #modelElements this level}.
 		 *
 		 * @observable
 		 * @readonly

--- a/src/headingcommand.js
+++ b/src/headingcommand.js
@@ -26,8 +26,9 @@ export default class HeadingCommand extends Command {
 		super( editor );
 
 		/**
-		 * If the selection starts in a one of headings of {@link #modelElements} the value gets name of heading model element.
-		 * Is set to false otherwise.
+		 * If the selection starts in a heading (which {@link #modelElements is supported by this command})
+		 * the value is set to the name of that heading model element.
+		 * It is  set to `false` otherwise.
 		 *
 		 * @observable
 		 * @readonly
@@ -35,7 +36,7 @@ export default class HeadingCommand extends Command {
 		 */
 
 		/**
-		 * Set of defined model's elements names that this command recognise.
+		 * Set of defined model's elements names that this command support.
 		 * See {@link module:heading/heading~HeadingOption}.
 		 *
 		 * @readonly
@@ -50,13 +51,6 @@ export default class HeadingCommand extends Command {
 	refresh() {
 		const block = first( this.editor.model.document.selection.getSelectedBlocks() );
 
-		/**
-		 * The name of a heading.
-		 *
-		 * @observable
-		 * @readonly
-		 * @member {Boolean|String} #value
-		 */
 		this.value = !!block && this.modelElements.includes( block.name ) && block.name;
 		this.isEnabled = !!block && this.modelElements.some( heading => checkCanBecomeHeading( block, heading, this.editor.model.schema ) );
 	}

--- a/src/headingcommand.js
+++ b/src/headingcommand.js
@@ -26,11 +26,12 @@ export default class HeadingCommand extends Command {
 		super( editor );
 
 		/**
-		 * Whether the selection starts in a heading of {@link #modelElements this level}.
+		 * If the selection starts in a one of headings of {@link #modelElements} the value gets name of heading model element.
+		 * Is set to false otherwise.
 		 *
 		 * @observable
 		 * @readonly
-		 * @member {Boolean} #value
+		 * @member {Boolean|String} #value
 		 */
 
 		/**

--- a/src/headingediting.js
+++ b/src/headingediting.js
@@ -51,6 +51,8 @@ export default class HeadingEditing extends Plugin {
 		const editor = this.editor;
 		const options = editor.config.get( 'heading.options' );
 
+		const modelElements = [];
+
 		for ( const option of options ) {
 			// Skip paragraph - it is defined in required Paragraph feature.
 			if ( option.model !== defaultModelElement ) {
@@ -61,10 +63,12 @@ export default class HeadingEditing extends Plugin {
 
 				editor.conversion.elementToElement( option );
 
-				// Register the heading command for this option.
-				editor.commands.add( option.model, new HeadingCommand( editor, option.model ) );
+				modelElements.push( option.model );
 			}
 		}
+
+		// Register the heading command for this option.
+		editor.commands.add( 'heading', new HeadingCommand( editor, modelElements ) );
 	}
 
 	/**

--- a/src/headingui.js
+++ b/src/headingui.js
@@ -95,7 +95,7 @@ export default class HeadingUI extends Plugin {
 
 			// Execute command when an item from the dropdown is selected.
 			this.listenTo( dropdownView, 'execute', evt => {
-				editor.execute( evt.source.commandName );
+				editor.execute( evt.source.commandName, evt.source.commandValue ? { value: evt.source.commandValue } : undefined );
 				editor.editing.view.focus();
 			} );
 

--- a/src/headingui.js
+++ b/src/headingui.js
@@ -33,7 +33,7 @@ export default class HeadingUI extends Plugin {
 		const dropdownTooltip = t( 'Heading' );
 
 		// Register UI component.
-		editor.ui.componentFactory.add( 'headings', locale => {
+		editor.ui.componentFactory.add( 'heading', locale => {
 			const commands = [];
 			const dropdownItems = new Collection();
 

--- a/tests/headingcommand.js
+++ b/tests/headingcommand.js
@@ -47,12 +47,6 @@ describe( 'HeadingCommand', () => {
 		} );
 	} );
 
-	afterEach( () => {
-		// for ( const modelElement in commands ) {
-		// 	commands[ modelElement ].destroy();
-		// }
-	} );
-
 	describe( 'modelElements', () => {
 		it( 'is set', () => {
 			expect( command.modelElements ).to.deep.equal( [ 'heading1', 'heading2', 'heading3' ] );

--- a/tests/headingcommand.js
+++ b/tests/headingcommand.js
@@ -16,23 +16,28 @@ const options = [
 ];
 
 describe( 'HeadingCommand', () => {
-	let editor, model, document, commands, root, schema;
+	let editor, model, document, command, root, schema;
 
 	beforeEach( () => {
 		return ModelTestEditor.create().then( newEditor => {
 			editor = newEditor;
 			model = editor.model;
 			document = model.document;
-			commands = {};
 			schema = model.schema;
 
 			editor.commands.add( 'paragraph', new ParagraphCommand( editor ) );
 			schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 
+			const modelElements = [];
+
 			for ( const option of options ) {
-				commands[ option.model ] = new HeadingCommand( editor, option.model );
+				modelElements.push( option.model );
 				schema.register( option.model, { inheritAllFrom: '$block' } );
 			}
+
+			command = new HeadingCommand( editor, modelElements );
+			editor.commands.add( 'heading', command );
+			schema.register( 'heading', { inheritAllFrom: '$block' } );
 
 			schema.register( 'notBlock' );
 			schema.extend( 'notBlock', { allowIn: '$root' } );
@@ -43,14 +48,14 @@ describe( 'HeadingCommand', () => {
 	} );
 
 	afterEach( () => {
-		for ( const modelElement in commands ) {
-			commands[ modelElement ].destroy();
-		}
+		// for ( const modelElement in commands ) {
+		// 	commands[ modelElement ].destroy();
+		// }
 	} );
 
-	describe( 'modelElement', () => {
+	describe( 'modelElements', () => {
 		it( 'is set', () => {
-			expect( commands.heading1.modelElement ).to.equal( 'heading1' );
+			expect( command.modelElements ).to.deep.equal( [ 'heading1', 'heading2', 'heading3' ] );
 		} );
 	} );
 
@@ -70,13 +75,13 @@ describe( 'HeadingCommand', () => {
 					];
 					writer.setSelection( ranges );
 				} );
-				expect( commands[ modelElement ].value ).to.be.true;
+				expect( command.value ).to.equal( modelElement );
 			} );
 
 			it( 'equals false if inside to non-block element', () => {
 				setData( model, '<notBlock>[foo]</notBlock>' );
 
-				expect( commands[ modelElement ].value ).to.be.false;
+				expect( command.value ).to.be.false;
 			} );
 
 			it( `equals false if moved from ${ modelElement } to non-block element`, () => {
@@ -87,18 +92,17 @@ describe( 'HeadingCommand', () => {
 					writer.setSelection( Range.createIn( element ) );
 				} );
 
-				expect( commands[ modelElement ].value ).to.be.false;
+				expect( command.value ).to.be.false;
 			} );
 
 			it( 'should be refreshed after calling refresh()', () => {
-				const command = commands[ modelElement ];
 				setData( model, `<${ modelElement }>[foo]</${ modelElement }><notBlock>foo</notBlock>` );
 				const element = document.getRoot().getChild( 1 );
 
 				model.change( writer => {
 					writer.setSelection( Range.createIn( element ) );
 
-					expect( command.value ).to.be.true;
+					expect( command.value ).to.equal( modelElement );
 					command.refresh();
 					expect( command.value ).to.be.false;
 				} );
@@ -108,13 +112,11 @@ describe( 'HeadingCommand', () => {
 
 	describe( 'execute()', () => {
 		it( 'should update value after execution', () => {
-			const command = commands.heading1;
-
 			setData( model, '<paragraph>[]</paragraph>' );
-			command.execute();
+			command.execute( { value: 'heading1' } );
 
 			expect( getData( model ) ).to.equal( '<heading1>[]</heading1>' );
-			expect( command.value ).to.be.true;
+			expect( command.value ).to.equal( 'heading1' );
 		} );
 
 		// https://github.com/ckeditor/ckeditor5-heading/issues/73
@@ -134,7 +136,7 @@ describe( 'HeadingCommand', () => {
 				'<fooBlock>de]f</fooBlock>'
 			);
 
-			commands.heading1.execute();
+			command.execute( { value: 'heading1' } );
 
 			expect( getData( model ) ).to.equal(
 				'<heading1>a[bc</heading1>' +
@@ -157,7 +159,7 @@ describe( 'HeadingCommand', () => {
 				'<paragraph>de]f</paragraph>'
 			);
 
-			commands.heading1.execute();
+			command.execute( { value: 'heading1' } );
 
 			expect( getData( model ) ).to.equal(
 				'<heading1>a[bc</heading1>' +
@@ -167,17 +169,31 @@ describe( 'HeadingCommand', () => {
 		} );
 
 		it( 'should use parent batch', () => {
-			const command = commands.heading1;
-
 			setData( model, '<paragraph>foo[]bar</paragraph>' );
 
 			model.change( writer => {
 				expect( writer.batch.deltas.length ).to.equal( 0 );
 
-				command.execute();
+				command.execute( { value: 'heading1' } );
 
 				expect( writer.batch.deltas.length ).to.be.above( 0 );
 			} );
+		} );
+
+		it( 'should do nothing on non-registered model elements', () => {
+			setData( model, '<heading1>[]</heading1>' );
+			command.execute( { value: 'paragraph' } );
+
+			expect( getData( model ) ).to.equal( '<heading1>[]</heading1>' );
+			expect( command.value ).to.equal( 'heading1' );
+		} );
+
+		it( 'should do nothing when empty value is passed', () => {
+			setData( model, '<heading1>[]</heading1>' );
+			command.execute();
+
+			expect( getData( model ) ).to.equal( '<heading1>[]</heading1>' );
+			expect( command.value ).to.equal( 'heading1' );
 		} );
 
 		describe( 'collapsed selection', () => {
@@ -191,7 +207,7 @@ describe( 'HeadingCommand', () => {
 			it( 'does nothing when executed with already applied option', () => {
 				setData( model, '<heading1>foo[]bar</heading1>' );
 
-				commands.heading1.execute();
+				command.execute( { value: 'heading1' } );
 				expect( getData( model ) ).to.equal( '<heading1>foo[]bar</heading1>' );
 			} );
 
@@ -200,7 +216,7 @@ describe( 'HeadingCommand', () => {
 				schema.extend( '$text', { allowIn: 'inlineImage' } );
 
 				setData( model, '<paragraph><inlineImage>foo[]</inlineImage>bar</paragraph>' );
-				commands.heading1.execute();
+				command.execute( { value: 'heading1' } );
 
 				expect( getData( model ) ).to.equal( '<heading1><inlineImage>foo[]</inlineImage>bar</heading1>' );
 			} );
@@ -208,7 +224,7 @@ describe( 'HeadingCommand', () => {
 			function test( from, to ) {
 				it( `converts ${ from.model } to ${ to.model } on collapsed selection`, () => {
 					setData( model, `<${ from.model }>foo[]bar</${ from.model }>` );
-					commands[ to.model ].execute();
+					command.execute( { value: to.model } );
 
 					expect( getData( model ) ).to.equal( `<${ to.model }>foo[]bar</${ to.model }>` );
 				} );
@@ -226,7 +242,7 @@ describe( 'HeadingCommand', () => {
 			it( 'converts all elements where selection is applied', () => {
 				setData( model, '<heading1>foo[</heading1><heading2>bar</heading2><heading3>baz]</heading3>' );
 
-				commands.heading3.execute();
+				command.execute( { value: 'heading3' } );
 
 				expect( getData( model ) ).to.equal(
 					'<heading3>foo[</heading3><heading3>bar</heading3><heading3>baz]</heading3>'
@@ -235,7 +251,7 @@ describe( 'HeadingCommand', () => {
 
 			it( 'does nothing to the elements with same option (#1)', () => {
 				setData( model, '<heading1>[foo</heading1><heading1>bar]</heading1>' );
-				commands.heading1.execute();
+				command.execute( { value: 'heading1' } );
 
 				expect( getData( model ) ).to.equal(
 					'<heading1>[foo</heading1><heading1>bar]</heading1>'
@@ -244,7 +260,7 @@ describe( 'HeadingCommand', () => {
 
 			it( 'does nothing to the elements with same option (#2)', () => {
 				setData( model, '<heading1>[foo</heading1><heading1>bar</heading1><heading2>baz]</heading2>' );
-				commands.heading1.execute();
+				command.execute( { value: 'heading1' } );
 
 				expect( getData( model ) ).to.equal(
 					'<heading1>[foo</heading1><heading1>bar</heading1><heading1>baz]</heading1>'
@@ -258,7 +274,7 @@ describe( 'HeadingCommand', () => {
 						`<${ fromElement }>foo[bar</${ fromElement }><${ fromElement }>baz]qux</${ fromElement }>`
 					);
 
-					commands[ toElement ].execute();
+					command.execute( { value: toElement } );
 
 					expect( getData( model ) ).to.equal(
 						`<${ toElement }>foo[bar</${ toElement }><${ toElement }>baz]qux</${ toElement }>`
@@ -274,12 +290,6 @@ describe( 'HeadingCommand', () => {
 		}
 
 		function test( modelElement ) {
-			let command;
-
-			beforeEach( () => {
-				command = commands[ modelElement ];
-			} );
-
 			describe( `${ modelElement } command`, () => {
 				it( 'should be enabled when inside another block', () => {
 					setData( model, '<paragraph>f{}oo</paragraph>' );

--- a/tests/headingediting.js
+++ b/tests/headingediting.js
@@ -49,9 +49,7 @@ describe( 'HeadingEditing', () => {
 
 	it( 'should register #commands', () => {
 		expect( editor.commands.get( 'paragraph' ) ).to.be.instanceOf( ParagraphCommand );
-		expect( editor.commands.get( 'heading1' ) ).to.be.instanceOf( HeadingCommand );
-		expect( editor.commands.get( 'heading2' ) ).to.be.instanceOf( HeadingCommand );
-		expect( editor.commands.get( 'heading3' ) ).to.be.instanceOf( HeadingCommand );
+		expect( editor.commands.get( 'heading' ) ).to.be.instanceOf( HeadingCommand );
 	} );
 
 	it( 'should convert heading1', () => {
@@ -153,9 +151,6 @@ describe( 'HeadingEditing', () => {
 					} )
 					.then( editor => {
 						model = editor.model;
-
-						expect( editor.commands.get( 'h4' ) ).to.be.instanceOf( HeadingCommand );
-						expect( editor.commands.get( 'paragraph' ) ).to.be.instanceOf( ParagraphCommand );
 
 						expect( model.schema.isRegistered( 'paragraph' ) ).to.be.true;
 						expect( model.schema.isRegistered( 'h4' ) ).to.be.true;

--- a/tests/headingui.js
+++ b/tests/headingui.js
@@ -76,7 +76,7 @@ describe( 'HeadingUI', () => {
 			expect( dropdown.buttonView.tooltip ).to.equal( 'Heading' );
 		} );
 
-		it( 'should execute format command on model execute event', () => {
+		it( 'should execute format command on model execute event for paragraph', () => {
 			const executeSpy = testUtils.sinon.spy( editor, 'execute' );
 			const dropdown = editor.ui.componentFactory.create( 'heading' );
 
@@ -84,7 +84,19 @@ describe( 'HeadingUI', () => {
 			dropdown.fire( 'execute' );
 
 			sinon.assert.calledOnce( executeSpy );
-			sinon.assert.calledWithExactly( executeSpy, 'paragraph' );
+			sinon.assert.calledWithExactly( executeSpy, 'paragraph', undefined );
+		} );
+
+		it( 'should execute format command on model execute event for heading', () => {
+			const executeSpy = testUtils.sinon.spy( editor, 'execute' );
+			const dropdown = editor.ui.componentFactory.create( 'heading' );
+
+			dropdown.commandName = 'heading';
+			dropdown.commandValue = 'heading1';
+			dropdown.fire( 'execute' );
+
+			sinon.assert.calledOnce( executeSpy );
+			sinon.assert.calledWithExactly( executeSpy, 'heading', { value: 'heading1' } );
 		} );
 
 		it( 'should focus view after command execution', () => {

--- a/tests/headingui.js
+++ b/tests/headingui.js
@@ -52,7 +52,7 @@ describe( 'HeadingUI', () => {
 			} )
 			.then( newEditor => {
 				editor = newEditor;
-				dropdown = editor.ui.componentFactory.create( 'headings' );
+				dropdown = editor.ui.componentFactory.create( 'heading' );
 
 				// Set data so the commands will be enabled.
 				setData( editor.model, '<paragraph>f{}oo</paragraph>' );
@@ -67,7 +67,7 @@ describe( 'HeadingUI', () => {
 
 	describe( 'init()', () => {
 		it( 'should register options feature component', () => {
-			const dropdown = editor.ui.componentFactory.create( 'headings' );
+			const dropdown = editor.ui.componentFactory.create( 'heading' );
 
 			expect( dropdown ).to.be.instanceOf( DropdownView );
 			expect( dropdown.buttonView.isEnabled ).to.be.true;
@@ -78,7 +78,7 @@ describe( 'HeadingUI', () => {
 
 		it( 'should execute format command on model execute event', () => {
 			const executeSpy = testUtils.sinon.spy( editor, 'execute' );
-			const dropdown = editor.ui.componentFactory.create( 'headings' );
+			const dropdown = editor.ui.componentFactory.create( 'heading' );
 
 			dropdown.commandName = 'paragraph';
 			dropdown.fire( 'execute' );
@@ -89,7 +89,7 @@ describe( 'HeadingUI', () => {
 
 		it( 'should focus view after command execution', () => {
 			const focusSpy = testUtils.sinon.spy( editor.editing.view, 'focus' );
-			const dropdown = editor.ui.componentFactory.create( 'headings' );
+			const dropdown = editor.ui.componentFactory.create( 'heading' );
 
 			dropdown.commandName = 'paragraph';
 			dropdown.fire( 'execute' );
@@ -98,7 +98,7 @@ describe( 'HeadingUI', () => {
 		} );
 
 		it( 'should add custom CSS class to dropdown', () => {
-			const dropdown = editor.ui.componentFactory.create( 'headings' );
+			const dropdown = editor.ui.componentFactory.create( 'heading' );
 
 			dropdown.render();
 
@@ -226,7 +226,7 @@ describe( 'HeadingUI', () => {
 					} )
 					.then( newEditor => {
 						editor = newEditor;
-						dropdown = editor.ui.componentFactory.create( 'headings' );
+						dropdown = editor.ui.componentFactory.create( 'heading' );
 						commands = {};
 
 						editor.config.get( 'heading.options' ).forEach( ( { model } ) => {

--- a/tests/headingui.js
+++ b/tests/headingui.js
@@ -106,41 +106,46 @@ describe( 'HeadingUI', () => {
 		} );
 
 		describe( 'model to command binding', () => {
-			let commands;
+			let command, paragraphCommand;
 
 			beforeEach( () => {
-				commands = {};
-
-				editor.config.get( 'heading.options' ).forEach( ( { model } ) => {
-					commands[ model ] = editor.commands.get( model );
-				} );
+				command = editor.commands.get( 'heading' );
+				paragraphCommand = editor.commands.get( 'paragraph' );
 			} );
 
 			it( 'isEnabled', () => {
-				for ( const name in commands ) {
-					commands[ name ].isEnabled = false;
-				}
+				command.isEnabled = false;
+				paragraphCommand.isEnabled = false;
 
 				expect( dropdown.buttonView.isEnabled ).to.be.false;
 
-				commands.heading2.isEnabled = true;
+				command.isEnabled = true;
+				expect( dropdown.buttonView.isEnabled ).to.be.true;
+
+				command.isEnabled = false;
+				expect( dropdown.buttonView.isEnabled ).to.be.false;
+
+				paragraphCommand.isEnabled = true;
 				expect( dropdown.buttonView.isEnabled ).to.be.true;
 			} );
 
 			it( 'label', () => {
-				for ( const name in commands ) {
-					commands[ name ].value = false;
-				}
+				command.value = false;
+				paragraphCommand.value = false;
 
 				expect( dropdown.buttonView.label ).to.equal( 'Choose heading' );
 
-				commands.heading2.value = true;
+				command.value = 'heading2';
 				expect( dropdown.buttonView.label ).to.equal( 'Heading 2' );
+				command.value = false;
+
+				paragraphCommand.value = true;
+				expect( dropdown.buttonView.label ).to.equal( 'Paragraph' );
 			} );
 		} );
 
 		describe( 'localization', () => {
-			let commands, editor, dropdown;
+			let command, paragraphCommand, editor, dropdown;
 
 			beforeEach( () => {
 				return localizedEditor( [
@@ -163,15 +168,15 @@ describe( 'HeadingUI', () => {
 
 				// Setting manually paragraph.value to `false` because there might be some content in editor
 				// after initialisation (for example empty <p></p> inserted when editor is empty).
-				commands.paragraph.value = false;
+				paragraphCommand.value = false;
 				expect( buttonView.label ).to.equal( 'Wybierz nagłówek' );
 				expect( buttonView.tooltip ).to.equal( 'Nagłówek' );
 
-				commands.paragraph.value = true;
+				paragraphCommand.value = true;
 				expect( buttonView.label ).to.equal( 'Akapit' );
 
-				commands.paragraph.value = false;
-				commands.heading1.value = true;
+				paragraphCommand.value = false;
+				command.value = 'heading1';
 				expect( buttonView.label ).to.equal( 'Nagłówek 1' );
 			} );
 
@@ -227,11 +232,8 @@ describe( 'HeadingUI', () => {
 					.then( newEditor => {
 						editor = newEditor;
 						dropdown = editor.ui.componentFactory.create( 'heading' );
-						commands = {};
-
-						editor.config.get( 'heading.options' ).forEach( ( { model } ) => {
-							commands[ model ] = editor.commands.get( model );
-						} );
+						command = editor.commands.get( 'heading' );
+						paragraphCommand = editor.commands.get( 'paragraph' );
 
 						editorElement.remove();
 

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -78,7 +78,7 @@ describe( 'Heading integration', () => {
 				'<paragraph>b]ar</paragraph>'
 			);
 
-			editor.execute( 'heading1' );
+			editor.execute( 'heading', { value: 'heading1' } );
 
 			expect( getModelData( model ) ).to.equal(
 				'<heading1>fo[o</heading1>' +
@@ -94,7 +94,7 @@ describe( 'Heading integration', () => {
 		it( 'does not create undo steps when applied to an existing heading (collapsed selection)', () => {
 			setModelData( model, '<heading1>foo[]bar</heading1>' );
 
-			editor.execute( 'heading1' );
+			editor.execute( 'heading', { value: 'heading1' } );
 			expect( getModelData( model ) ).to.equal( '<heading1>foo[]bar</heading1>' );
 
 			expect( editor.commands.get( 'undo' ).isEnabled ).to.be.false;
@@ -103,7 +103,7 @@ describe( 'Heading integration', () => {
 		it( 'does not create undo steps when applied to an existing heading (non–collapsed selection)', () => {
 			setModelData( model, '<heading1>[foo</heading1><heading1>bar]</heading1>' );
 
-			editor.execute( 'heading1' );
+			editor.execute( 'heading', { value: 'heading1' } );
 			expect( getModelData( model ) ).to.equal( '<heading1>[foo</heading1><heading1>bar]</heading1>' );
 
 			expect( editor.commands.get( 'undo' ).isEnabled ).to.be.false;

--- a/tests/manual/heading.js
+++ b/tests/manual/heading.js
@@ -15,7 +15,7 @@ import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [ Enter, Typing, Undo, Heading, Paragraph ],
-		toolbar: [ 'headings', '|', 'undo', 'redo' ]
+		toolbar: [ 'heading', '|', 'undo', 'redo' ]
 	} )
 	.then( editor => {
 		window.editor = editor;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Update naming of UI components & commands.

BREAKING CHANGE: Renamed `headings` drop-down UI component to `heading`.
BREAKING CHANGE: The "heading1", "heading2" and "heading3" commands are no longer available. Replaced by "heading" command that accepts heading model element name as a value.
BREAKING CHANGE: The `HeadingCommand#value` is no longer Boolean - only. Now it can have a name of heading model element.
BREAKING CHANGE: The `HeadingCommand` constructor's second parameter is now an array of supported model elements.

---

### Additional information

* PR of : https://github.com/ckeditor/ckeditor5-alignment/pull/25.
* Renamed 'headings' to 'heading'.
* Removed `headingn` commands in favor of `heading` one command.
