### PR TITLE
Docs: Update custom-heading-elements snippet to the latest conversion…

### DIFF
--- a/docs/_snippets/features/custom-heading-elements.js
+++ b/docs/_snippets/features/custom-heading-elements.js
@@ -23,7 +23,7 @@ ClassicEditor
 					},
 					title: 'Heading 2 (fancy)',
 					class: 'ck-heading_heading2_fancy',
-					priority: 'high'
+					converterPriority: 'high'
 				}
 			]
 		},

--- a/docs/features/headings.md
+++ b/docs/features/headings.md
@@ -52,7 +52,7 @@ ClassicEditor
 
 ### Configuring custom heading elements
 
-It is also possible to define fully custom elements for headings by using the {@link module:engine/view/elementdefinition~ElementDefinition advanced format} of the {@link module:heading/heading~HeadingConfig#options `heading.options`} configuration option.
+It is also possible to define fully custom elements for headings by using the {@link module:engine/conversion/conversion~ConverterDefinition advanced format} of the {@link module:heading/heading~HeadingConfig#options `heading.options`} configuration option.
 
 For example, the following editor will support the following two heading options at the same time: `<h2 class="fancy">` and `<h2>`:
 
@@ -91,7 +91,7 @@ ClassicEditor
 					class: 'ck-heading_heading2_fancy',
 
 					// It needs to be converted before the standard 'heading2'.
-					priority: 'high'
+					converterPriority: 'high'
 				}
 			]
 		}

--- a/src/heading.js
+++ b/src/heading.js
@@ -113,4 +113,5 @@ export default class Heading extends Plugin {
  * @property {String} class The class which will be added to the dropdown item representing this option.
  * @property {String} [icon] Icon used by {@link module:heading/headingbuttonsui~HeadingButtonsUI}. It can be omitted when using
  * the default configuration.
+ * @extends module:engine/conversion/conversion~ConverterDefinition
  */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Update custom-heading-elements snippet to the latest conversion API changes. Closes #110.

---

### Additional information

* I've added this to review as I've changed some links which IMO were wrong but I'd like to have a second opinion on that.
* The heading option is used as-is in so I've added `@extends` to it.
