### PR TITLE
Convert 'h1' headers to 'h2' by default

### DIFF
--- a/docs/features/headings.md
+++ b/docs/features/headings.md
@@ -14,7 +14,9 @@ The {@link module:heading/heading~Heading} feature enables support for headings.
 
 ## Heading levels
 
-By default this feature is configured to support `<h2>`, `<h3>` and `<h4>` elements which are named: "Heading 1", "Heading 2" and "Heading 3", respectively. The rationale behind starting from `<h2>` is that `<h1>` should be reserved for the page's main title and the page content will usually start from `<h2>`.
+By default this feature is configured to support `<h2>`, `<h3>` and `<h4>` elements which are named: "Heading 1", "Heading 2" and "Heading 3", respectively. Additionally, the `<h1>` element is supported and is converted to `<h2>` ("Heading 1") by default.
+
+The rationale behind such behaviour is that `<h1>` should be reserved for the page's main title and the page content will usually start from `<h2>`. However, when content with `<h1>` elements is used in the editor (set or pasted) it makes more sense from the user perspective and content semantics to convert `<h1>` elements into `<h2>` instead of paragraphs (`<p>`).
 
 <info-box hint>
 	You can read more about why the editor should not create `<h1>` elements in the [Headings section of Editor Recommendations](http://ckeditor.github.io/editor-recommendations/features/headings.html).

--- a/docs/features/headings.md
+++ b/docs/features/headings.md
@@ -14,7 +14,7 @@ The {@link module:heading/heading~Heading} feature enables support for headings.
 
 ## Heading levels
 
-By default this feature is configured to support `<h2>`, `<h3>` and `<h4>` elements which are named: "Heading 1", "Heading 2" and "Heading 3", respectively. Additionally, the `<h1>` element is supported and is converted to `<h2>` ("Heading 1") by default.
+By default this feature is configured to support `<h2>`, `<h3>` and `<h4>` elements which are named: "Heading 1", "Heading 2" and "Heading 3", respectively. Additionally, the `<h1>` element is supported and is converted to `<h2>` ("Heading 1") with a low priority by default.
 
 The rationale behind such behaviour is that `<h1>` should be reserved for the page's main title and the page content will usually start from `<h2>`. However, when content with `<h1>` elements is used in the editor (set or pasted) it makes more sense from the user perspective and content semantics to convert `<h1>` elements into `<h2>` instead of paragraphs (`<p>`).
 

--- a/src/headingediting.js
+++ b/src/headingediting.js
@@ -12,6 +12,7 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import HeadingCommand from './headingcommand';
 
 import priorities from '@ckeditor/ckeditor5-utils/src/priorities';
+import { upcastElementToElement } from '@ckeditor/ckeditor5-engine/src/conversion/upcast-converters';
 
 const defaultModelElement = 'paragraph';
 
@@ -104,14 +105,12 @@ export default class HeadingEditing extends Plugin {
 	 * @param {module:core/editor/editor~Editor} editor Editor instance on which to add the `h1` conversion.
 	 */
 	_addDefaultH1Conversion( editor ) {
-		editor.conversion.elementToElement( {
+		editor.conversion.for( 'upcast' ).add( upcastElementToElement( {
 			model: 'heading1',
 			view: 'h1',
-			title: 'Heading 1',
-			class: 'ck-heading_heading1',
 			// With a `low` priority, `paragraph` plugin autoparagraphing mechanism is executed. Make sure
 			// this listener is called before it. If not, `h1` will be transformed into a paragraph.
 			converterPriority: priorities.get( 'low' ) + 1
-		} );
+		} ) );
 	}
 }

--- a/src/headingediting.js
+++ b/src/headingediting.js
@@ -98,22 +98,31 @@ export default class HeadingEditing extends Plugin {
 	}
 
 	/**
-	 * Adds default converter for `h1` -> `heading1`. It will be added only if configuration with `h2` -> `heading1` mapping is used.
+	 * Adds default conversion for `h1` -> `heading1` with a low priority.
+	 *
+	 * The default conversion will be added only if `heading.options` configuration with `h2` -> `heading1`
+	 * conversion is defined and there are no other conversion definitions for `h1` provided.
 	 *
 	 * @private
-	 * @param editor
-	 * @param options
+	 * @param {module:core/editor/editor~Editor} editor Editor instance on which to add the `h1` conversion.
+	 * @param {Array.<module:engine/conversion/conversion~ConverterDefinition} definitions List of already used conversion
+	 * definitions. The added default `h1` conversion is based on this list.
 	 */
-	_addDefaultH1Conversion( editor, options ) {
-		// Add `h1` -> `heading1` conversion with a low priority. This means if no other conversion was provided,
-		// `h1` will be handled here. Proceed only if `heading1` -> `h2` mapping was registered.
-		const heading1 = options.find( option => option.model === 'heading1' && option.view === 'h2' );
+	_addDefaultH1Conversion( editor, definitions ) {
+		// Do not add default conversions if conversion for `<h1>` is already defined.
+		if ( definitions.find( option => option.view === 'h1' ) ) {
+			return;
+		}
+
+		// Add `h1` -> `heading1` conversion with a low priority. This means if no other conversions were provided,
+		// `h1` will be handled here. Proceed only if `h2` -> `heading1` conversion was configured.
+		const heading1 = definitions.find( option => option.model === 'heading1' && option.view === 'h2' );
 		if ( heading1 ) {
 			const optionH1 = Object.assign( {}, heading1 );
 
 			optionH1.view = 'h1';
-			// With a 'low' priority `paragraph` plugin autoparagraphing mechanism is used.
-			// Make sure this listener is called before it. If not, 'h1' will be transformed into paragraph.
+			// With a `low` priority, `paragraph` plugin autoparagraphing mechanism is executed. Make sure
+			// this listener is called before it. If not, `h1` will be transformed into a paragraph.
 			optionH1.converterPriority = priorities.get( 'low' ) + 1;
 
 			editor.conversion.elementToElement( optionH1 );

--- a/src/headingediting.js
+++ b/src/headingediting.js
@@ -69,7 +69,7 @@ export default class HeadingEditing extends Plugin {
 			}
 		}
 
-		this._addDefaultH1Conversion( editor, options );
+		this._addDefaultH1Conversion( editor );
 
 		// Register the heading command for this option.
 		editor.commands.add( 'heading', new HeadingCommand( editor, modelElements ) );
@@ -100,32 +100,18 @@ export default class HeadingEditing extends Plugin {
 	/**
 	 * Adds default conversion for `h1` -> `heading1` with a low priority.
 	 *
-	 * The default conversion will be added only if `heading.options` configuration with `h2` -> `heading1`
-	 * conversion is defined and there are no other conversion definitions for `h1` provided.
-	 *
 	 * @private
 	 * @param {module:core/editor/editor~Editor} editor Editor instance on which to add the `h1` conversion.
-	 * @param {Array.<module:engine/conversion/conversion~ConverterDefinition} definitions List of already used conversion
-	 * definitions. The added default `h1` conversion is based on this list.
 	 */
-	_addDefaultH1Conversion( editor, definitions ) {
-		// Do not add default conversions if conversion for `<h1>` is already defined.
-		if ( definitions.find( option => option.view === 'h1' ) ) {
-			return;
-		}
-
-		// Add `h1` -> `heading1` conversion with a low priority. This means if no other conversions were provided,
-		// `h1` will be handled here. Proceed only if `h2` -> `heading1` conversion was configured.
-		const heading1 = definitions.find( option => option.model === 'heading1' && option.view === 'h2' );
-		if ( heading1 ) {
-			const optionH1 = Object.assign( {}, heading1 );
-
-			optionH1.view = 'h1';
+	_addDefaultH1Conversion( editor ) {
+		editor.conversion.elementToElement( {
+			model: 'heading1',
+			view: 'h1',
+			title: 'Heading 1',
+			class: 'ck-heading_heading1',
 			// With a `low` priority, `paragraph` plugin autoparagraphing mechanism is executed. Make sure
 			// this listener is called before it. If not, `h1` will be transformed into a paragraph.
-			optionH1.converterPriority = priorities.get( 'low' ) + 1;
-
-			editor.conversion.elementToElement( optionH1 );
-		}
+			converterPriority: priorities.get( 'low' ) + 1
+		} );
 	}
 }

--- a/tests/headingediting.js
+++ b/tests/headingediting.js
@@ -135,32 +135,23 @@ describe( 'HeadingEditing', () => {
 			elementToElementSpy = testUtils.sinon.spy( Conversion.prototype, 'elementToElement' );
 		} );
 
-		it( 'should set default h1 conversion for default `options.heading` config', () => {
+		it( 'should set default h1 conversion with default `options.heading` config', () => {
 			return VirtualTestEditor
 				.create( {
 					plugins: [ HeadingEditing ]
 				} )
 				.then( () => {
-					expect( elementToElementSpy.calledWith( getDefaultConversion() ) ).to.true;
+					expect( elementToElementSpy.calledWith( {
+						model: 'heading1',
+						view: 'h1',
+						title: 'Heading 1',
+						class: 'ck-heading_heading1',
+						converterPriority: priorities.get( 'low' ) + 1
+					} ) ).to.true;
 				} );
 		} );
 
-		it( 'should set default h1 conversion based on provided config if `h2` -> `heading1` conversion defined', () => {
-			const options = [
-				{ model: 'heading1', view: 'h2', title: 'User H2' }
-			];
-
-			return VirtualTestEditor
-				.create( {
-					plugins: [ HeadingEditing ],
-					heading: { options }
-				} )
-				.then( () => {
-					expect( elementToElementSpy.calledWith( getDefaultConversion( options[ 0 ] ) ) ).to.true;
-				} );
-		} );
-
-		it( 'should not set default h1 conversion if no `h2` -> `heading1` conversion defined', () => {
+		it( 'should set default h1 conversion independently from `options.heading` config', () => {
 			const options = [
 				{ model: 'heading1', view: 'h3', title: 'User H3' },
 				{ model: 'heading2', view: 'h4', title: 'User H4' }
@@ -172,71 +163,15 @@ describe( 'HeadingEditing', () => {
 					heading: { options }
 				} )
 				.then( () => {
-					expect( elementToElementSpy.neverCalledWith( getDefaultConversion( options[ 0 ] ) ) ).to.true;
+					expect( elementToElementSpy.calledWith( {
+						model: 'heading1',
+						view: 'h1',
+						title: 'Heading 1',
+						class: 'ck-heading_heading1',
+						converterPriority: priorities.get( 'low' ) + 1
+					} ) ).to.true;
 				} );
 		} );
-
-		it( 'should use user defined h1 conversion (low + 1 priority)', () => {
-			const options = [
-				{ model: 'paragraph', title: 'paragraph' },
-				{ model: 'heading3', view: 'h1', title: 'User H1', converterPriority: priorities.get( 'low' ) + 1 },
-				{ model: 'heading4', view: 'h2', title: 'User H2' }
-			];
-
-			return VirtualTestEditor
-				.create( {
-					plugins: [ HeadingEditing ],
-					heading: { options }
-				} )
-				.then( editor => {
-					editor.setData( '<h2>h2</h2><h1>h1</h1>' );
-
-					expect( getData( editor.model, { withoutSelection: true } ) )
-						.to.equal( '<heading4>h2</heading4><heading3>h1</heading3>' );
-
-					expect( editor.getData() ).to.equal( '<h2>h2</h2><h1>h1</h1>' );
-				} );
-		} );
-
-		it( 'should use user defined h1 conversion not adding default one (default priority)', () => {
-			const options = [
-				{ model: 'paragraph', title: 'paragraph' },
-				{ model: 'heading1', view: 'h6', title: 'User H6' },
-				{ model: 'heading2', view: 'h1', title: 'User H1' },
-				{ model: 'heading3', view: 'h2', title: 'User H2' }
-			];
-
-			return VirtualTestEditor
-				.create( {
-					plugins: [ HeadingEditing ],
-					heading: { options }
-				} )
-				.then( editor => {
-					editor.setData( '<h2>h2</h2><h1>h1</h1>' );
-
-					expect( elementToElementSpy.neverCalledWith( getDefaultConversion() ) ).to.true;
-					expect( elementToElementSpy.neverCalledWith( getDefaultConversion( options[ 1 ] ) ) ).to.true;
-
-					expect( getData( editor.model, { withoutSelection: true } ) )
-						.to.equal( '<heading3>h2</heading3><heading2>h1</heading2>' );
-
-					expect( editor.getData() ).to.equal( '<h2>h2</h2><h1>h1</h1>' );
-				} );
-		} );
-
-		function getDefaultConversion( conversionOptionBase = null ) {
-			if ( conversionOptionBase ) {
-				return Object.assign( {}, conversionOptionBase, { view: 'h1', converterPriority: priorities.get( 'low' ) + 1 } );
-			}
-
-			return {
-				model: 'heading1',
-				view: 'h1',
-				title: 'Heading 1',
-				class: 'ck-heading_heading1',
-				converterPriority: priorities.get( 'low' ) + 1
-			};
-		}
 	} );
 
 	it( 'should not blow up if there\'s no enter command in the editor', () => {

--- a/tests/headingediting.js
+++ b/tests/headingediting.js
@@ -151,7 +151,7 @@ describe( 'HeadingEditing', () => {
 				} );
 		} );
 
-		it( 'should set default h1 conversion independently from `options.heading` config', () => {
+		it( 'should define the default h1 to heading1 converter when heading.options is specified', () => {
 			const options = [
 				{ model: 'heading1', view: 'h3', title: 'User H3' },
 				{ model: 'heading2', view: 'h4', title: 'User H4' }

--- a/tests/headingediting.js
+++ b/tests/headingediting.js
@@ -73,6 +73,13 @@ describe( 'HeadingEditing', () => {
 		expect( editor.getData() ).to.equal( '<h4>foobar</h4>' );
 	} );
 
+	it( 'should convert h1 to heading1', () => {
+		editor.setData( '<h1>foobar</h1>' );
+
+		expect( getData( model, { withoutSelection: true } ) ).to.equal( '<heading1>foobar</heading1>' );
+		expect( editor.getData() ).to.equal( '<h2>foobar</h2>' );
+	} );
+
 	describe( 'user defined', () => {
 		beforeEach( () => {
 			return VirtualTestEditor
@@ -113,6 +120,35 @@ describe( 'HeadingEditing', () => {
 				.to.equal( '<heading1>foobar</heading1><paragraph>Normal paragraph</paragraph>' );
 
 			expect( editor.getData() ).to.equal( '<h1>foobar</h1><p>Normal paragraph</p>' );
+		} );
+
+		it( 'should use user defined h1 conversion instead of the default one (high priority)', () => {
+			editor.setData( '<h2>h2</h2><h1>h1</h1>' );
+
+			expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>h2</paragraph><heading1>h1</heading1>' );
+			expect( editor.getData() ).to.equal( '<p>h2</p><h1>h1</h1>' );
+		} );
+
+		it( 'should use user defined h1 conversion instead of the default one (default priority)', () => {
+			return VirtualTestEditor
+				.create( {
+					plugins: [ HeadingEditing ],
+					heading: {
+						options: [
+							{ model: 'paragraph', title: 'paragraph' },
+							{ model: 'heading1', view: 'h2', title: 'User H1' },
+							{ model: 'heading2', view: 'h1', title: 'User H2' }
+						]
+					}
+				} )
+				.then( editor => {
+					editor.setData( '<h2>h2</h2><h1>h1</h1>' );
+
+					expect( getData( editor.model, { withoutSelection: true } ) )
+						.to.equal( '<heading1>h2</heading1><heading2>h1</heading2>' );
+
+					expect( editor.getData() ).to.equal( '<h2>h2</h2><h1>h1</h1>' );
+				} );
 		} );
 	} );
 

--- a/tests/headingediting.js
+++ b/tests/headingediting.js
@@ -135,7 +135,7 @@ describe( 'HeadingEditing', () => {
 			elementToElementSpy = testUtils.sinon.spy( Conversion.prototype, 'elementToElement' );
 		} );
 
-		it( 'should set default h1 conversion with default `options.heading` config', () => {
+		it( 'should define the default h1 to heading1 converter when heading.options is not specified', () => {
 			return VirtualTestEditor
 				.create( {
 					plugins: [ HeadingEditing ]

--- a/tests/manual/heading.html
+++ b/tests/manual/heading.html
@@ -1,5 +1,6 @@
 <div id="editor">
-	<h2>Heading 1</h2>
+	<h2>Heading 1 (h1)</h2>
+	<h2>Heading 1 (h2)</h2>
 	<h3>Heading 2</h3>
 	<h4>Heading 3</h4>
 	<p>Paragraph</p>

--- a/tests/manual/heading.html
+++ b/tests/manual/heading.html
@@ -1,5 +1,5 @@
 <div id="editor">
-	<h2>Heading 1 (h1)</h2>
+	<h1>Heading 1 (h1)</h1>
 	<h2>Heading 1 (h2)</h2>
 	<h3>Heading 2</h3>
 	<h4>Heading 3</h4>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: The `h1` headers are now converted to `h2` headers instead of paragraphs by default. Closes #98. Closes ckeditor/ckeditor5-paste-from-office#2.

---

### Additional information

I have added a [low priority conversion to `Heading` plugin](https://github.com/ckeditor/ckeditor5-heading/blob/c40186737cf093cbcf957334368f1e8bfd0df5dc/src/headingediting.js#L111) which converts `h1` into `heading1` in a model.

The one thing I'm not 100% sure about are the "entry conditions". It seems it makes sense to check if any `h1` conversions are already defined/used to not add default one in such cases (already covered in this PR):

https://github.com/ckeditor/ckeditor5-heading/blob/c40186737cf093cbcf957334368f1e8bfd0df5dc/src/headingediting.js#L112-L114

Also the default `h1` conversion is added only if `h2 -> heading1` conversion is already defined. However, `h2 -> heading1` conversion may be defined in:

1. a default config (so in the one not defined by the user or the one defined by the user but identical to default one - these are two separate cases btw.),
1. any config (default, user provided - identical/not-identical to default one).

In this PR, the second option is used - if `heading.options` config contains `h2 -> heading1` conversion definition, the default `h1` low priority conversion will be added.