### PR TITLE
Remove Position, Range, Selection imports from engine/model.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^11.0.1",
-    "@ckeditor/ckeditor5-ui": "^11.1.0",
-    "@ckeditor/ckeditor5-utils": "^11.0.0",
-    "@ckeditor/ckeditor5-engine": "^11.0.0",
     "@ckeditor/ckeditor5-paragraph": "^10.0.3",
-    "@ckeditor/ckeditor5-theme-lark": "^11.1.0"
+    "@ckeditor/ckeditor5-theme-lark": "^11.1.0",
+    "@ckeditor/ckeditor5-ui": "^11.1.0",
+    "@ckeditor/ckeditor5-utils": "^11.0.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-cloud-services": "^10.1.0",
     "@ckeditor/ckeditor5-editor-classic": "^11.0.1",
+    "@ckeditor/ckeditor5-engine": "^11.0.0",
     "@ckeditor/ckeditor5-enter": "^10.1.2",
     "@ckeditor/ckeditor5-image": "^11.0.0",
     "@ckeditor/ckeditor5-typing": "^11.0.1",

--- a/tests/headingcommand.js
+++ b/tests/headingcommand.js
@@ -6,7 +6,6 @@
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
 import ParagraphCommand from '@ckeditor/ckeditor5-paragraph/src/paragraphcommand';
 import HeadingCommand from '../src/headingcommand';
-import Range from '@ckeditor/ckeditor5-engine/src/model/range';
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 const options = [
@@ -65,7 +64,7 @@ describe( 'HeadingCommand', () => {
 				model.change( writer => {
 					const ranges = [
 						...model.document.selection.getRanges(),
-						Range.createFromParentsAndOffsets( element, 3, element, 3 )
+						writer.createRange( writer.createPositionAt( element, 3 ) )
 					];
 					writer.setSelection( ranges );
 				} );
@@ -83,7 +82,7 @@ describe( 'HeadingCommand', () => {
 				const element = document.getRoot().getChild( 1 );
 
 				model.change( writer => {
-					writer.setSelection( Range.createIn( element ) );
+					writer.setSelection( writer.createRangeIn( element ) );
 				} );
 
 				expect( command.value ).to.be.false;
@@ -94,7 +93,7 @@ describe( 'HeadingCommand', () => {
 				const element = document.getRoot().getChild( 1 );
 
 				model.change( writer => {
-					writer.setSelection( Range.createIn( element ) );
+					writer.setSelection( writer.createRangeIn( element ) );
 
 					expect( command.value ).to.equal( modelElement );
 					command.refresh();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Remove Position, Range, Selection imports from engine/model and engine/view.

---

### Additional information

* Part of: https://github.com/ckeditor/ckeditor5-engine/pull/1585.
