### PR TITLE
#121 Provide h4, h5, h6 as defaultIcons for button view

### DIFF
--- a/src/headingbuttonsui.js
+++ b/src/headingbuttonsui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md.
  */
 

--- a/src/headingbuttonsui.js
+++ b/src/headingbuttonsui.js
@@ -14,11 +14,17 @@ import { getLocalizedOptions } from './utils';
 import iconHeading1 from '../theme/icons/heading1.svg';
 import iconHeading2 from '../theme/icons/heading2.svg';
 import iconHeading3 from '../theme/icons/heading3.svg';
+import iconHeading4 from '../theme/icons/heading4.svg';
+import iconHeading5 from '../theme/icons/heading5.svg';
+import iconHeading6 from '../theme/icons/heading6.svg';
 
 const defaultIcons = {
 	heading1: iconHeading1,
 	heading2: iconHeading2,
-	heading3: iconHeading3
+	heading3: iconHeading3,
+	heading4: iconHeading4,
+	heading5: iconHeading5,
+	heading6: iconHeading6
 };
 
 /**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Provide h4, h5, h6 as defaultIcons for button view . Closes #121.