### PR TITLE
Set UI buttons as toggleable

### DIFF
--- a/src/headingbuttonsui.js
+++ b/src/headingbuttonsui.js
@@ -88,6 +88,7 @@ export default class HeadingButtonsUI extends Plugin {
 			view.label = option.title;
 			view.icon = option.icon || defaultIcons[ option.model ];
 			view.tooltip = true;
+			view.isToggleable = true;
 			view.bind( 'isEnabled' ).to( command );
 			view.bind( 'isOn' ).to( command, 'value', value => value == option.model );
 

--- a/tests/headingbuttonsui.js
+++ b/tests/headingbuttonsui.js
@@ -99,6 +99,17 @@ describe( 'HeadingButtonUI', () => {
 			sinon.assert.calledOnce( executeCommandSpy );
 			sinon.assert.calledWithExactly( executeCommandSpy, 'heading', { value: 'heading1' } );
 		} );
+
+		it( 'should be initialized as toggleable button', () => {
+			const factory = editor.ui.componentFactory;
+
+			expect( factory.create( 'heading1' ).isToggleable ).to.be.true;
+			expect( factory.create( 'heading2' ).isToggleable ).to.be.true;
+			expect( factory.create( 'heading3' ).isToggleable ).to.be.true;
+			expect( factory.create( 'heading4' ).isToggleable ).to.be.true;
+			expect( factory.create( 'heading5' ).isToggleable ).to.be.true;
+			expect( factory.create( 'heading6' ).isToggleable ).to.be.true;
+		} );
 	} );
 
 	describe( 'custom config', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Set UI buttons as toggleable.

---

### Additional information

Requires: ckeditor/ckeditor5-ui#517
