### PR TITLE
i/353: Focus the editor before executing a command

### DIFF
--- a/src/headingbuttonsui.js
+++ b/src/headingbuttonsui.js
@@ -94,6 +94,7 @@ export default class HeadingButtonsUI extends Plugin {
 
 			view.on( 'execute', () => {
 				editor.execute( 'heading', { value: option.model } );
+				editor.editing.view.focus();
 			} );
 
 			return view;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Focus the editor before executing toolbar buttons' command.

### Additonal information:
Master PR: https://github.com/ckeditor/ckeditor5/pull/6066
