### PR TITLE
Added missing view.Document to ViewDocumentFragment

### DIFF
--- a/src/title.js
+++ b/src/title.js
@@ -12,7 +12,6 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 
 import ViewDocumentFragment from '@ckeditor/ckeditor5-engine/src/view/documentfragment';
 import ViewDowncastWriter from '@ckeditor/ckeditor5-engine/src/view/downcastwriter';
-import ViewDocument from '@ckeditor/ckeditor5-engine/src/view/document';
 import first from '@ckeditor/ckeditor5-utils/src/first';
 import {
 	needsPlaceholder,
@@ -142,13 +141,14 @@ export default class Title extends Plugin {
 	 * @returns {String} The body of the document.
 	 */
 	getBody() {
-		const data = this.editor.data;
-		const model = this.editor.model;
-		const root = this.editor.model.document.getRoot();
-		const viewWriter = new ViewDowncastWriter( new ViewDocument() );
+		const editor = this.editor;
+		const data = editor.data;
+		const model = editor.model;
+		const root = editor.model.document.getRoot();
+		const viewWriter = new ViewDowncastWriter( editor.editing.view.document );
 
 		const rootRange = model.createRangeIn( root );
-		const viewDocumentFragment = new ViewDocumentFragment();
+		const viewDocumentFragment = new ViewDocumentFragment( editor.editing.view.document );
 
 		// Convert the entire root to view.
 		data.mapper.clearBindings();
@@ -171,7 +171,7 @@ export default class Title extends Plugin {
 		viewWriter.remove( viewWriter.createRangeOn( viewDocumentFragment.getChild( 0 ) ) );
 
 		// view -> data
-		return this.editor.data.processor.toData( viewDocumentFragment );
+		return editor.data.processor.toData( viewDocumentFragment );
 	}
 
 	/**

--- a/tests/title-integration.js
+++ b/tests/title-integration.js
@@ -40,7 +40,7 @@ describe( 'Title integration', () => {
 
 	describe( 'with basic styles', () => {
 		// See: https://github.com/ckeditor/ckeditor5/issues/6427
-		it( 'does not blow up when applying basic styles', () => {
+		it( 'should work when basic styles are applied to the content', () => {
 			editor.setData( '<h1>Title</h1><p>Foo</p>' );
 
 			editor.model.change( writer => {

--- a/tests/title-integration.js
+++ b/tests/title-integration.js
@@ -38,7 +38,7 @@ describe( 'Title integration', () => {
 		return editor.destroy();
 	} );
 
-	describe( 'getBody()', () => {
+	describe( 'with basic styles', () => {
 		// See: https://github.com/ckeditor/ckeditor5/issues/6427
 		it( 'does not blow up when applying basic styles', () => {
 			editor.setData( '<h1>Title</h1><p>Foo</p>' );

--- a/tests/title-integration.js
+++ b/tests/title-integration.js
@@ -1,0 +1,61 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global document */
+
+import Title from '../src/title';
+import Heading from '../src/heading.js';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Enter from '@ckeditor/ckeditor5-enter/src/enter';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import { getData as getModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+
+describe( 'Title integration', () => {
+	let editor, model, doc, element;
+
+	beforeEach( () => {
+		element = document.createElement( 'div' );
+		document.body.appendChild( element );
+
+		return ClassicTestEditor
+			.create( element, {
+				plugins: [ Paragraph, Heading, Enter, Bold, Title ]
+			} )
+			.then( newEditor => {
+				editor = newEditor;
+				model = editor.model;
+				doc = model.document;
+			} );
+	} );
+
+	afterEach( () => {
+		element.remove();
+
+		return editor.destroy();
+	} );
+
+	describe( 'getBody()', () => {
+		// See: https://github.com/ckeditor/ckeditor5/issues/6427
+		it( 'does not blow up when applying basic styles', () => {
+			editor.setData( '<h1>Title</h1><p>Foo</p>' );
+
+			editor.model.change( writer => {
+				writer.setSelection( doc.getRoot().getChild( 1 ), 'on' );
+			} );
+
+			editor.execute( 'bold' );
+
+			expect( editor.plugins.get( Title ).getBody() ).to.equal(
+				'<p><strong>Foo</strong></p>'
+			);
+
+			expect( getModelData( model ) ).to.equal(
+				'<title><title-content>Title</title-content></title><paragraph>[<$text bold="true">Foo</$text>]</paragraph>'
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Added missing `view.Document` instance to the `ViewDocumentFragment` class. Closes ckeditor/ckeditor5#6427.

---

### Additional information

This plugin was missed during https://github.com/ckeditor/ckeditor5-engine/pull/1826. 
